### PR TITLE
feat(nvim): add oil.nvim file explorer

### DIFF
--- a/linux/.config/nvim/lua/plugins/oil.lua
+++ b/linux/.config/nvim/lua/plugins/oil.lua
@@ -1,0 +1,12 @@
+-- oil.nvim: edit the filesystem like a buffer. SPC f f = open parent dir.
+return {
+  "stevearc/oil.nvim",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  lazy = false,
+  keys = {
+    { "<leader>ff", "<cmd>Oil<CR>", desc = "Open file explorer (oil)" },
+  },
+  opts = {
+    view_options = { show_hidden = true },
+  },
+}

--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -6,7 +6,6 @@ return {
   cmd = "Telescope",
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
-    { "<leader>ff", "<cmd>Telescope find_files<CR>", desc = "Find files" },
     { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },
     { "<leader>sg", "<cmd>Telescope live_grep<CR>", desc = "Grep project" },
     { "<leader>sb", "<cmd>Telescope current_buffer_fuzzy_find<CR>", desc = "Search buffer" },

--- a/macbook/.config/nvim/lazy-lock.json
+++ b/macbook/.config/nvim/lazy-lock.json
@@ -1,7 +1,9 @@
 {
   "diffview.nvim": { "branch": "main", "commit": "4516612fe98ff56ae0415a259ff6361a89419b0a" },
-  "lazy.nvim": { "branch": "main", "commit": "85c7ff3711b730b4030d03144f6db6375044ae82" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "neogit": { "branch": "master", "commit": "a0847c4bea5a5f92a36e3f3bf7da99d7d685d3ac" },
+  "nvim-web-devicons": { "branch": "master", "commit": "dad71387de386a946b123079d0e53f23028f3abd" },
+  "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
   "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },

--- a/macbook/.config/nvim/lua/plugins/oil.lua
+++ b/macbook/.config/nvim/lua/plugins/oil.lua
@@ -1,0 +1,12 @@
+-- oil.nvim: edit the filesystem like a buffer. SPC f f = open parent dir.
+return {
+  "stevearc/oil.nvim",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  lazy = false,
+  keys = {
+    { "<leader>ff", "<cmd>Oil<CR>", desc = "Open file explorer (oil)" },
+  },
+  opts = {
+    view_options = { show_hidden = true },
+  },
+}

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -6,7 +6,6 @@ return {
   cmd = "Telescope",
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
-    { "<leader>ff", "<cmd>Telescope find_files<CR>", desc = "Find files" },
     { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },
     { "<leader>sg", "<cmd>Telescope live_grep<CR>", desc = "Grep project" },
     { "<leader>sb", "<cmd>Telescope current_buffer_fuzzy_find<CR>", desc = "Search buffer" },


### PR DESCRIPTION
## What
- oil.nvim added both platforms — edit filesystem as a buffer, hidden files shown
- SPC f f opens oil
- reassigned SPC f f from telescope find_files; SPC SPC still finds files

## Test
- headless lazy sync clean, no errors
- keymaps resolve: SPC f f -> oil, SPC SPC -> find files

🤖 Generated with [Claude Code](https://claude.com/claude-code)