### PR TITLE
feat(nvim): java lsp + treesitter highlight

### DIFF
--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -1,0 +1,63 @@
+-- LSP: mason installs language servers, nvim-lspconfig provides their configs.
+-- jdtls = Java. mason-lspconfig (v2) auto-enables installed servers.
+-- Keymaps live under SPC c (code) and bind per-buffer when an LSP attaches.
+return {
+  {
+    "williamboman/mason.nvim",
+    build = ":MasonUpdate",
+    opts = {},
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    event = { "BufReadPre", "BufNewFile" },
+    dependencies = {
+      "williamboman/mason.nvim",
+      "neovim/nvim-lspconfig",
+    },
+    opts = {
+      ensure_installed = { "jdtls" },
+    },
+    config = function(_, opts)
+      require("mason-lspconfig").setup(opts)
+
+      -- jdtls's own JVM needs Java 21+. Projects may target older Java; only
+      -- the server runtime is pinned here. Prefer $JDTLS_JAVA_HOME, else the
+      -- newest SDKMAN java >= 21. Nil = fall back to JAVA_HOME/PATH.
+      local function jdtls_java_home()
+        if vim.env.JDTLS_JAVA_HOME then
+          return vim.env.JDTLS_JAVA_HOME
+        end
+        local dirs = vim.fn.glob(vim.fn.expand("~/.sdkman/candidates/java") .. "/*", true, true)
+        local best, best_major
+        for _, dir in ipairs(dirs) do
+          local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("^(%d+)"))
+          if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
+            if not best_major or major > best_major then
+              best, best_major = dir, major
+            end
+          end
+        end
+        return best
+      end
+
+      local jhome = jdtls_java_home()
+      if jhome then
+        vim.lsp.config("jdtls", { cmd_env = { JAVA_HOME = jhome } })
+      end
+
+      vim.api.nvim_create_autocmd("LspAttach", {
+        desc = "LSP buffer-local keymaps",
+        callback = function(ev)
+          local function m(lhs, rhs, desc)
+            vim.keymap.set("n", lhs, rhs, { buffer = ev.buf, desc = desc })
+          end
+          m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
+          m("<leader>cD", vim.lsp.buf.references, "Find usages")
+          m("<leader>cf", function()
+            vim.lsp.buf.format({ async = true })
+          end, "Format buffer")
+        end,
+      })
+    end,
+  },
+}

--- a/linux/.config/nvim/lua/plugins/treesitter.lua
+++ b/linux/.config/nvim/lua/plugins/treesitter.lua
@@ -1,0 +1,15 @@
+-- nvim-treesitter: syntax highlighting via tree-sitter parsers.
+return {
+  "nvim-treesitter/nvim-treesitter",
+  branch = "master",
+  build = ":TSUpdate",
+  event = { "BufReadPost", "BufNewFile" },
+  opts = {
+    ensure_installed = { "java", "lua", "vim", "vimdoc" },
+    highlight = { enable = true },
+    indent = { enable = true },
+  },
+  config = function(_, opts)
+    require("nvim-treesitter.configs").setup(opts)
+  end,
+}

--- a/linux/.config/nvim/lua/plugins/which-key.lua
+++ b/linux/.config/nvim/lua/plugins/which-key.lua
@@ -6,6 +6,7 @@ return {
     preset = "helix",
     spec = {
       { "<leader>b", group = "buffer" },
+      { "<leader>c", group = "code" },
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
       { "<leader>p", group = "project" },

--- a/macbook/.config/nvim/lazy-lock.json
+++ b/macbook/.config/nvim/lazy-lock.json
@@ -1,8 +1,12 @@
 {
   "diffview.nvim": { "branch": "main", "commit": "4516612fe98ff56ae0415a259ff6361a89419b0a" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "mason-lspconfig.nvim": { "branch": "main", "commit": "a4068c3ebd4cb335b25239e5ea35c22ee6007962" },
+  "mason.nvim": { "branch": "main", "commit": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d" },
   "neogit": { "branch": "master", "commit": "a0847c4bea5a5f92a36e3f3bf7da99d7d685d3ac" },
-  "nvim-web-devicons": { "branch": "master", "commit": "dad71387de386a946b123079d0e53f23028f3abd" },
+  "nvim-lspconfig": { "branch": "master", "commit": "d5b6e3db4c17b0146f63a2fc47e2027a754b2cb1" },
+  "nvim-treesitter": { "branch": "master", "commit": "cf12346a3414fa1b06af75c79faebe7f76df080a" },
+  "nvim-web-devicons": { "branch": "master", "commit": "09d1324e264c6950262dbe02a9bce2933a6800db" },
   "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -1,0 +1,63 @@
+-- LSP: mason installs language servers, nvim-lspconfig provides their configs.
+-- jdtls = Java. mason-lspconfig (v2) auto-enables installed servers.
+-- Keymaps live under SPC c (code) and bind per-buffer when an LSP attaches.
+return {
+  {
+    "williamboman/mason.nvim",
+    build = ":MasonUpdate",
+    opts = {},
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    event = { "BufReadPre", "BufNewFile" },
+    dependencies = {
+      "williamboman/mason.nvim",
+      "neovim/nvim-lspconfig",
+    },
+    opts = {
+      ensure_installed = { "jdtls" },
+    },
+    config = function(_, opts)
+      require("mason-lspconfig").setup(opts)
+
+      -- jdtls's own JVM needs Java 21+. Projects may target older Java; only
+      -- the server runtime is pinned here. Prefer $JDTLS_JAVA_HOME, else the
+      -- newest SDKMAN java >= 21. Nil = fall back to JAVA_HOME/PATH.
+      local function jdtls_java_home()
+        if vim.env.JDTLS_JAVA_HOME then
+          return vim.env.JDTLS_JAVA_HOME
+        end
+        local dirs = vim.fn.glob(vim.fn.expand("~/.sdkman/candidates/java") .. "/*", true, true)
+        local best, best_major
+        for _, dir in ipairs(dirs) do
+          local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("^(%d+)"))
+          if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
+            if not best_major or major > best_major then
+              best, best_major = dir, major
+            end
+          end
+        end
+        return best
+      end
+
+      local jhome = jdtls_java_home()
+      if jhome then
+        vim.lsp.config("jdtls", { cmd_env = { JAVA_HOME = jhome } })
+      end
+
+      vim.api.nvim_create_autocmd("LspAttach", {
+        desc = "LSP buffer-local keymaps",
+        callback = function(ev)
+          local function m(lhs, rhs, desc)
+            vim.keymap.set("n", lhs, rhs, { buffer = ev.buf, desc = desc })
+          end
+          m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
+          m("<leader>cD", vim.lsp.buf.references, "Find usages")
+          m("<leader>cf", function()
+            vim.lsp.buf.format({ async = true })
+          end, "Format buffer")
+        end,
+      })
+    end,
+  },
+}

--- a/macbook/.config/nvim/lua/plugins/treesitter.lua
+++ b/macbook/.config/nvim/lua/plugins/treesitter.lua
@@ -1,0 +1,15 @@
+-- nvim-treesitter: syntax highlighting via tree-sitter parsers.
+return {
+  "nvim-treesitter/nvim-treesitter",
+  branch = "master",
+  build = ":TSUpdate",
+  event = { "BufReadPost", "BufNewFile" },
+  opts = {
+    ensure_installed = { "java", "lua", "vim", "vimdoc" },
+    highlight = { enable = true },
+    indent = { enable = true },
+  },
+  config = function(_, opts)
+    require("nvim-treesitter.configs").setup(opts)
+  end,
+}

--- a/macbook/.config/nvim/lua/plugins/which-key.lua
+++ b/macbook/.config/nvim/lua/plugins/which-key.lua
@@ -6,6 +6,7 @@ return {
     preset = "helix",
     spec = {
       { "<leader>b", group = "buffer" },
+      { "<leader>c", group = "code" },
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
       { "<leader>p", group = "project" },


### PR DESCRIPTION
## What

Java support in nvim. jdtls LSP + treesitter highlight.

## Changes

- **treesitter** — new plugin spec, pin `master` branch (main branch dropped `configs` module), java parser.
- **lsp** — mason + mason-lspconfig + nvim-lspconfig. `jdtls` auto-installed. jdtls JVM needs java 21+ but project runtime untouched: point it at newest SDKMAN java >= 21 via `cmd_env`. Override with `$JDTLS_JAVA_HOME`.
- **keymaps** (SPC c = code group in which-key):
  - `SPC c d` go to definition
  - `SPC c D` find usages
  - `SPC c f` format buffer
  - `SPC f s` save already existed, unchanged.
- macbook + linux both.

## Verified

Tested on real gradle project (`~/dev/optimizer`): jdtls attaches on java 25, gradle import completes, go-to-definition resolves, all three keymaps bind on LspAttach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)