### PR TITLE
feat(nvim): claude code terminal + kill keybind

### DIFF
--- a/linux/.config/nvim/lua/plugins/toggleterm.lua
+++ b/linux/.config/nvim/lua/plugins/toggleterm.lua
@@ -3,15 +3,17 @@
 --   SPC t s  bottom split, full width, pushes buffers up (30% height)
 --   SPC t v  right split, 30% width, pushes buffers left
 --   SPC t c  float 90%, runs claude code; toggle hides it (process stays alive)
+--   SPC t q  kill the active terminal, ending its process
 -- Distinct <count> per mapping = three independent, persistent terminals.
 
 -- Dedicated Claude Code terminal. Built once, reused so toggle hides/shows the
 -- same job instead of spawning a new one. close_on_exit=false keeps the buffer
--- if claude quits.
+-- if claude quits. Rebuilt if it was killed (e.g. via SPC t q).
 local claude_term
 local function toggle_claude()
-  if not claude_term then
-    claude_term = require("toggleterm.terminal").Terminal:new({
+  local tt = require("toggleterm.terminal")
+  if not claude_term or not tt.get(claude_term.id, true) then
+    claude_term = tt.Terminal:new({
       cmd = "claude",
       direction = "float",
       close_on_exit = false,
@@ -26,6 +28,19 @@ local function toggle_claude()
     })
   end
   claude_term:toggle()
+end
+
+-- Kill the active terminal outright: shutdown() closes the window, wipes the
+-- buffer and stops the job. Prefer the focused terminal, else the last focused.
+local function kill_terminal()
+  local tt = require("toggleterm.terminal")
+  local id = tt.get_focused_id()
+  local term = (id and tt.get(id, true)) or tt.get_last_focused()
+  if term then
+    term:shutdown()
+  else
+    vim.notify("No active toggleterm terminal", vim.log.levels.WARN)
+  end
 end
 
 return {
@@ -53,5 +68,6 @@ return {
     { "<leader>ts", "<cmd>2ToggleTerm direction=horizontal<cr>", desc = "Terminal (bottom split)" },
     { "<leader>tv", "<cmd>3ToggleTerm direction=vertical<cr>", desc = "Terminal (right split)" },
     { "<leader>tc", toggle_claude, desc = "Terminal (Claude Code, 90%)" },
+    { "<leader>tq", kill_terminal, desc = "Kill active terminal" },
   },
 }

--- a/linux/.config/nvim/lua/plugins/toggleterm.lua
+++ b/linux/.config/nvim/lua/plugins/toggleterm.lua
@@ -2,7 +2,32 @@
 --   SPC t t  floating terminal, 80% of the screen, over the buffers
 --   SPC t s  bottom split, full width, pushes buffers up (30% height)
 --   SPC t v  right split, 30% width, pushes buffers left
+--   SPC t c  float 90%, runs claude code; toggle hides it (process stays alive)
 -- Distinct <count> per mapping = three independent, persistent terminals.
+
+-- Dedicated Claude Code terminal. Built once, reused so toggle hides/shows the
+-- same job instead of spawning a new one. close_on_exit=false keeps the buffer
+-- if claude quits.
+local claude_term
+local function toggle_claude()
+  if not claude_term then
+    claude_term = require("toggleterm.terminal").Terminal:new({
+      cmd = "claude",
+      direction = "float",
+      close_on_exit = false,
+      float_opts = {
+        width = function()
+          return math.floor(vim.o.columns * 0.9)
+        end,
+        height = function()
+          return math.floor(vim.o.lines * 0.9)
+        end,
+      },
+    })
+  end
+  claude_term:toggle()
+end
+
 return {
   "akinsho/toggleterm.nvim",
   version = "*",
@@ -27,5 +52,6 @@ return {
     { "<leader>tt", "<cmd>1ToggleTerm direction=float<cr>", desc = "Terminal (float 80%)" },
     { "<leader>ts", "<cmd>2ToggleTerm direction=horizontal<cr>", desc = "Terminal (bottom split)" },
     { "<leader>tv", "<cmd>3ToggleTerm direction=vertical<cr>", desc = "Terminal (right split)" },
+    { "<leader>tc", toggle_claude, desc = "Terminal (Claude Code, 90%)" },
   },
 }

--- a/macbook/.config/nvim/lua/plugins/toggleterm.lua
+++ b/macbook/.config/nvim/lua/plugins/toggleterm.lua
@@ -3,15 +3,17 @@
 --   SPC t s  bottom split, full width, pushes buffers up (30% height)
 --   SPC t v  right split, 30% width, pushes buffers left
 --   SPC t c  float 90%, runs claude code; toggle hides it (process stays alive)
+--   SPC t q  kill the active terminal, ending its process
 -- Distinct <count> per mapping = three independent, persistent terminals.
 
 -- Dedicated Claude Code terminal. Built once, reused so toggle hides/shows the
 -- same job instead of spawning a new one. close_on_exit=false keeps the buffer
--- if claude quits.
+-- if claude quits. Rebuilt if it was killed (e.g. via SPC t q).
 local claude_term
 local function toggle_claude()
-  if not claude_term then
-    claude_term = require("toggleterm.terminal").Terminal:new({
+  local tt = require("toggleterm.terminal")
+  if not claude_term or not tt.get(claude_term.id, true) then
+    claude_term = tt.Terminal:new({
       cmd = "claude",
       direction = "float",
       close_on_exit = false,
@@ -26,6 +28,19 @@ local function toggle_claude()
     })
   end
   claude_term:toggle()
+end
+
+-- Kill the active terminal outright: shutdown() closes the window, wipes the
+-- buffer and stops the job. Prefer the focused terminal, else the last focused.
+local function kill_terminal()
+  local tt = require("toggleterm.terminal")
+  local id = tt.get_focused_id()
+  local term = (id and tt.get(id, true)) or tt.get_last_focused()
+  if term then
+    term:shutdown()
+  else
+    vim.notify("No active toggleterm terminal", vim.log.levels.WARN)
+  end
 end
 
 return {
@@ -53,5 +68,6 @@ return {
     { "<leader>ts", "<cmd>2ToggleTerm direction=horizontal<cr>", desc = "Terminal (bottom split)" },
     { "<leader>tv", "<cmd>3ToggleTerm direction=vertical<cr>", desc = "Terminal (right split)" },
     { "<leader>tc", toggle_claude, desc = "Terminal (Claude Code, 90%)" },
+    { "<leader>tq", kill_terminal, desc = "Kill active terminal" },
   },
 }

--- a/macbook/.config/nvim/lua/plugins/toggleterm.lua
+++ b/macbook/.config/nvim/lua/plugins/toggleterm.lua
@@ -2,7 +2,32 @@
 --   SPC t t  floating terminal, 80% of the screen, over the buffers
 --   SPC t s  bottom split, full width, pushes buffers up (30% height)
 --   SPC t v  right split, 30% width, pushes buffers left
+--   SPC t c  float 90%, runs claude code; toggle hides it (process stays alive)
 -- Distinct <count> per mapping = three independent, persistent terminals.
+
+-- Dedicated Claude Code terminal. Built once, reused so toggle hides/shows the
+-- same job instead of spawning a new one. close_on_exit=false keeps the buffer
+-- if claude quits.
+local claude_term
+local function toggle_claude()
+  if not claude_term then
+    claude_term = require("toggleterm.terminal").Terminal:new({
+      cmd = "claude",
+      direction = "float",
+      close_on_exit = false,
+      float_opts = {
+        width = function()
+          return math.floor(vim.o.columns * 0.9)
+        end,
+        height = function()
+          return math.floor(vim.o.lines * 0.9)
+        end,
+      },
+    })
+  end
+  claude_term:toggle()
+end
+
 return {
   "akinsho/toggleterm.nvim",
   version = "*",
@@ -27,5 +52,6 @@ return {
     { "<leader>tt", "<cmd>1ToggleTerm direction=float<cr>", desc = "Terminal (float 80%)" },
     { "<leader>ts", "<cmd>2ToggleTerm direction=horizontal<cr>", desc = "Terminal (bottom split)" },
     { "<leader>tv", "<cmd>3ToggleTerm direction=vertical<cr>", desc = "Terminal (right split)" },
+    { "<leader>tc", toggle_claude, desc = "Terminal (Claude Code, 90%)" },
   },
 }


### PR DESCRIPTION
## What

Follow-up to #7 (merged). Two terminal keybinds that landed after that PR merged.

## Keybindings (SPC t = terminal group)

- `SPC t c` — float 90%, auto-runs `claude`; toggle hides window but keeps the process alive
- `SPC t q` — kill the active terminal (focused, else last focused); ends its process

## Verified

Driven headless at 200x50:
- claude terminal 180x45 (90%); toggle hides window with job still running; reopen reuses same buffer.
- kill wipes buffer + stops job + unregisters; claude terminal rebuilds after a kill.

macbook + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)