### PR TITLE
feat(nvim): markdown render preview

### DIFF
--- a/linux/.config/nvim/lazy-lock.json
+++ b/linux/.config/nvim/lazy-lock.json
@@ -5,6 +5,7 @@
   "nvim-web-devicons": { "branch": "master", "commit": "dad71387de386a946b123079d0e53f23028f3abd" },
   "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "render-markdown.nvim": { "branch": "main", "commit": "f422cb5c6855f150e2ddcfaf44e7157b98b34f6a" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
   "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },
   "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }

--- a/linux/.config/nvim/lua/plugins/render-markdown.lua
+++ b/linux/.config/nvim/lua/plugins/render-markdown.lua
@@ -28,7 +28,19 @@ return {
   "MeanderingProgrammer/render-markdown.nvim",
   ft = { "markdown" },
   dependencies = { "nvim-treesitter/nvim-treesitter" },
-  opts = {},
+  -- anti_conceal off: keep the cursor line rendered instead of revealing raw
+  -- markup. cursorline (markdown-only) marks where the cursor is instead.
+  init = function()
+    vim.api.nvim_create_autocmd("FileType", {
+      pattern = "markdown",
+      callback = function()
+        vim.opt_local.cursorline = true
+      end,
+    })
+  end,
+  opts = {
+    anti_conceal = { enabled = false },
+  },
   keys = {
     { "<leader>mr", toggle_preview, desc = "Markdown render preview (right 80%)" },
   },

--- a/linux/.config/nvim/lua/plugins/render-markdown.lua
+++ b/linux/.config/nvim/lua/plugins/render-markdown.lua
@@ -1,0 +1,35 @@
+-- render-markdown: in-editor markdown rendering (headings, tables, code, lists,
+-- checkboxes) via treesitter. No browser, no external binary. SPC m = markdown.
+--   SPC m r  open current buffer as a rendered preview in a right vsplit (80%
+--            width); press again to close the preview split.
+-- The preview shows the SAME buffer, so edits on the left reflect live on the
+-- right. render-markdown conceals markup in every window showing the buffer, so
+-- the split reads as rendered output.
+local preview_win
+
+local function toggle_preview()
+  if preview_win and vim.api.nvim_win_is_valid(preview_win) then
+    vim.api.nvim_win_close(preview_win, false)
+    preview_win = nil
+    return
+  end
+  local buf = vim.api.nvim_get_current_buf()
+  if vim.bo[buf].filetype ~= "markdown" then
+    vim.notify("Not a markdown buffer", vim.log.levels.WARN)
+    return
+  end
+  vim.cmd("botright vsplit")
+  preview_win = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_buf(preview_win, buf)
+  vim.api.nvim_win_set_width(preview_win, math.floor(vim.o.columns * 0.8))
+end
+
+return {
+  "MeanderingProgrammer/render-markdown.nvim",
+  ft = { "markdown" },
+  dependencies = { "nvim-treesitter/nvim-treesitter" },
+  opts = {},
+  keys = {
+    { "<leader>mr", toggle_preview, desc = "Markdown render preview (right 80%)" },
+  },
+}

--- a/linux/.config/nvim/lua/plugins/treesitter.lua
+++ b/linux/.config/nvim/lua/plugins/treesitter.lua
@@ -5,7 +5,7 @@ return {
   build = ":TSUpdate",
   event = { "BufReadPost", "BufNewFile" },
   opts = {
-    ensure_installed = { "java", "lua", "vim", "vimdoc" },
+    ensure_installed = { "java", "lua", "markdown", "markdown_inline", "vim", "vimdoc" },
     highlight = { enable = true },
     indent = { enable = true },
   },

--- a/linux/.config/nvim/lua/plugins/which-key.lua
+++ b/linux/.config/nvim/lua/plugins/which-key.lua
@@ -9,6 +9,7 @@ return {
       { "<leader>c", group = "code" },
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
+      { "<leader>m", group = "markdown" },
       { "<leader>p", group = "project" },
       { "<leader>q", group = "quit" },
       { "<leader>s", group = "search" },

--- a/macbook/.config/nvim/lazy-lock.json
+++ b/macbook/.config/nvim/lazy-lock.json
@@ -9,6 +9,7 @@
   "nvim-web-devicons": { "branch": "master", "commit": "09d1324e264c6950262dbe02a9bce2933a6800db" },
   "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "render-markdown.nvim": { "branch": "main", "commit": "f422cb5c6855f150e2ddcfaf44e7157b98b34f6a" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
   "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
   "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },

--- a/macbook/.config/nvim/lua/plugins/render-markdown.lua
+++ b/macbook/.config/nvim/lua/plugins/render-markdown.lua
@@ -28,7 +28,19 @@ return {
   "MeanderingProgrammer/render-markdown.nvim",
   ft = { "markdown" },
   dependencies = { "nvim-treesitter/nvim-treesitter" },
-  opts = {},
+  -- anti_conceal off: keep the cursor line rendered instead of revealing raw
+  -- markup. cursorline (markdown-only) marks where the cursor is instead.
+  init = function()
+    vim.api.nvim_create_autocmd("FileType", {
+      pattern = "markdown",
+      callback = function()
+        vim.opt_local.cursorline = true
+      end,
+    })
+  end,
+  opts = {
+    anti_conceal = { enabled = false },
+  },
   keys = {
     { "<leader>mr", toggle_preview, desc = "Markdown render preview (right 80%)" },
   },

--- a/macbook/.config/nvim/lua/plugins/render-markdown.lua
+++ b/macbook/.config/nvim/lua/plugins/render-markdown.lua
@@ -1,0 +1,35 @@
+-- render-markdown: in-editor markdown rendering (headings, tables, code, lists,
+-- checkboxes) via treesitter. No browser, no external binary. SPC m = markdown.
+--   SPC m r  open current buffer as a rendered preview in a right vsplit (80%
+--            width); press again to close the preview split.
+-- The preview shows the SAME buffer, so edits on the left reflect live on the
+-- right. render-markdown conceals markup in every window showing the buffer, so
+-- the split reads as rendered output.
+local preview_win
+
+local function toggle_preview()
+  if preview_win and vim.api.nvim_win_is_valid(preview_win) then
+    vim.api.nvim_win_close(preview_win, false)
+    preview_win = nil
+    return
+  end
+  local buf = vim.api.nvim_get_current_buf()
+  if vim.bo[buf].filetype ~= "markdown" then
+    vim.notify("Not a markdown buffer", vim.log.levels.WARN)
+    return
+  end
+  vim.cmd("botright vsplit")
+  preview_win = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_buf(preview_win, buf)
+  vim.api.nvim_win_set_width(preview_win, math.floor(vim.o.columns * 0.8))
+end
+
+return {
+  "MeanderingProgrammer/render-markdown.nvim",
+  ft = { "markdown" },
+  dependencies = { "nvim-treesitter/nvim-treesitter" },
+  opts = {},
+  keys = {
+    { "<leader>mr", toggle_preview, desc = "Markdown render preview (right 80%)" },
+  },
+}

--- a/macbook/.config/nvim/lua/plugins/treesitter.lua
+++ b/macbook/.config/nvim/lua/plugins/treesitter.lua
@@ -5,7 +5,7 @@ return {
   build = ":TSUpdate",
   event = { "BufReadPost", "BufNewFile" },
   opts = {
-    ensure_installed = { "java", "lua", "vim", "vimdoc" },
+    ensure_installed = { "java", "lua", "markdown", "markdown_inline", "vim", "vimdoc" },
     highlight = { enable = true },
     indent = { enable = true },
   },

--- a/macbook/.config/nvim/lua/plugins/which-key.lua
+++ b/macbook/.config/nvim/lua/plugins/which-key.lua
@@ -9,6 +9,7 @@ return {
       { "<leader>c", group = "code" },
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
+      { "<leader>m", group = "markdown" },
       { "<leader>p", group = "project" },
       { "<leader>q", group = "quit" },
       { "<leader>s", group = "search" },


### PR DESCRIPTION
add markdown preview. render-markdown.nvim, pure lua, no browser.

## what
- **SPC m r** open active buffer rendered in right vsplit 80%, press again close
- render inline: headings, tables, code, checkboxes
- `anti_conceal` off = cursor line stay rendered
- `cursorline` on for markdown only = mark cursor line
- markdown + markdown_inline treesitter parsers
- which-key `SPC m` = markdown group
- macbook + linux both, lazy-lock pinned both

## test
- parse clean all files
- headless: plugin load on ft=markdown, split width = 80%, cursorline true

base = feat/nvim-keymap-rebind (stacked; retargets to master when base merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)