### PR TITLE
feat(karabiner): windows-style keys

### DIFF
--- a/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
+++ b/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
@@ -43,6 +43,16 @@
           "to": [{ "key_code": "tab", "modifiers": ["left_command"] }]
         }
       ]
+    },
+    {
+      "description": "Ctrl+Space = Spotlight (send Cmd+Space)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": { "key_code": "spacebar", "modifiers": { "mandatory": ["left_control"] } },
+          "to": [{ "key_code": "spacebar", "modifiers": ["left_command"] }]
+        }
+      ]
     }
   ]
 }

--- a/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
+++ b/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
@@ -1,0 +1,48 @@
+{
+  "title": "Windows-style keys (Ctrl clipboard + Alt+Tab)",
+  "rules": [
+    {
+      "description": "Ctrl+C/V/X/A/Z = Cmd (copy/paste/cut/all/undo)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": { "key_code": "c", "modifiers": { "mandatory": ["left_control"] } },
+          "to": [{ "key_code": "c", "modifiers": ["left_command"] }]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "v", "modifiers": { "mandatory": ["left_control"] } },
+          "to": [{ "key_code": "v", "modifiers": ["left_command"] }]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "x", "modifiers": { "mandatory": ["left_control"] } },
+          "to": [{ "key_code": "x", "modifiers": ["left_command"] }]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "a", "modifiers": { "mandatory": ["left_control"] } },
+          "to": [{ "key_code": "a", "modifiers": ["left_command"] }]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "z", "modifiers": { "mandatory": ["left_control"] } },
+          "to": [{ "key_code": "z", "modifiers": ["left_command"] }]
+        }
+      ]
+    },
+    {
+      "description": "Alt+Tab = switcher (send Cmd+Tab). Alt+Shift+Tab cycles back",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": { "mandatory": ["left_option"], "optional": ["shift"] }
+          },
+          "to": [{ "key_code": "tab", "modifiers": ["left_command"] }]
+        }
+      ]
+    }
+  ]
+}

--- a/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
+++ b/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
@@ -32,19 +32,6 @@
       ]
     },
     {
-      "description": "Alt+Tab = switcher (send Cmd+Tab). Alt+Shift+Tab cycles back",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "tab",
-            "modifiers": { "mandatory": ["left_option"], "optional": ["shift"] }
-          },
-          "to": [{ "key_code": "tab", "modifiers": ["left_command"] }]
-        }
-      ]
-    },
-    {
       "description": "Ctrl+Space = Spotlight (send Cmd+Space)",
       "manipulators": [
         {

--- a/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
+++ b/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
@@ -1,43 +1,28 @@
 {
-  "title": "Windows-style keys (Ctrl clipboard + Alt+Tab)",
+  "title": "Windows-style keys",
   "rules": [
     {
-      "description": "Ctrl+C/V/X/A/Z = Cmd (copy/paste/cut/all/undo)",
+      "description": "Swap Ctrl and Cmd (Ctrl behaves as Command everywhere)",
       "manipulators": [
         {
           "type": "basic",
-          "from": { "key_code": "c", "modifiers": { "mandatory": ["left_control"] } },
-          "to": [{ "key_code": "c", "modifiers": ["left_command"] }]
+          "from": { "key_code": "left_control", "modifiers": { "optional": ["any"] } },
+          "to": [{ "key_code": "left_command" }]
         },
         {
           "type": "basic",
-          "from": { "key_code": "v", "modifiers": { "mandatory": ["left_control"] } },
-          "to": [{ "key_code": "v", "modifiers": ["left_command"] }]
+          "from": { "key_code": "left_command", "modifiers": { "optional": ["any"] } },
+          "to": [{ "key_code": "left_control" }]
         },
         {
           "type": "basic",
-          "from": { "key_code": "x", "modifiers": { "mandatory": ["left_control"] } },
-          "to": [{ "key_code": "x", "modifiers": ["left_command"] }]
+          "from": { "key_code": "right_control", "modifiers": { "optional": ["any"] } },
+          "to": [{ "key_code": "right_command" }]
         },
         {
           "type": "basic",
-          "from": { "key_code": "a", "modifiers": { "mandatory": ["left_control"] } },
-          "to": [{ "key_code": "a", "modifiers": ["left_command"] }]
-        },
-        {
-          "type": "basic",
-          "from": { "key_code": "z", "modifiers": { "mandatory": ["left_control"] } },
-          "to": [{ "key_code": "z", "modifiers": ["left_command"] }]
-        }
-      ]
-    },
-    {
-      "description": "Ctrl+Space = Spotlight (send Cmd+Space)",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": { "key_code": "spacebar", "modifiers": { "mandatory": ["left_control"] } },
-          "to": [{ "key_code": "spacebar", "modifiers": ["left_command"] }]
+          "from": { "key_code": "right_command", "modifiers": { "optional": ["any"] } },
+          "to": [{ "key_code": "right_control" }]
         }
       ]
     }

--- a/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
+++ b/macbook/.config/karabiner/assets/complex_modifications/windows-clipboard.json
@@ -2,27 +2,75 @@
   "title": "Windows-style keys",
   "rules": [
     {
-      "description": "Swap Ctrl and Cmd (Ctrl behaves as Command everywhere)",
+      "description": "Swap Ctrl and Cmd (Ctrl = Command; native in terminals)",
       "manipulators": [
         {
           "type": "basic",
           "from": { "key_code": "left_control", "modifiers": { "optional": ["any"] } },
-          "to": [{ "key_code": "left_command" }]
+          "to": [{ "key_code": "left_command" }],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$",
+                "^org\\.alacritty$",
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
           "from": { "key_code": "left_command", "modifiers": { "optional": ["any"] } },
-          "to": [{ "key_code": "left_control" }]
+          "to": [{ "key_code": "left_control" }],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$",
+                "^org\\.alacritty$",
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
           "from": { "key_code": "right_control", "modifiers": { "optional": ["any"] } },
-          "to": [{ "key_code": "right_command" }]
+          "to": [{ "key_code": "right_command" }],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$",
+                "^org\\.alacritty$",
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
           "from": { "key_code": "right_command", "modifiers": { "optional": ["any"] } },
-          "to": [{ "key_code": "right_control" }]
+          "to": [{ "key_code": "right_control" }],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$",
+                "^org\\.alacritty$",
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -7,9 +7,16 @@ return {
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
     { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },
-    { "<leader>sg", "<cmd>Telescope live_grep<CR>", desc = "Grep project" },
+    { "<leader>sp", "<cmd>Telescope live_grep<CR>", desc = "Search project text" },
     { "<leader>sb", "<cmd>Telescope current_buffer_fuzzy_find<CR>", desc = "Search buffer" },
     { "<leader>bi", "<cmd>Telescope buffers<CR>", desc = "Buffer list" },
   },
-  opts = {},
+  opts = {
+    pickers = {
+      -- rg --files respects .gitignore; avoids `find` fallback that lists ignored files
+      find_files = {
+        find_command = { "rg", "--files", "--color", "never" },
+      },
+    },
+  },
 }

--- a/macbook/.zshrc
+++ b/macbook/.zshrc
@@ -122,3 +122,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
+
+# Add JBang to environment
+alias j!=jbang
+export PATH="$HOME/.jbang/bin:$PATH"


### PR DESCRIPTION
## What

Karabiner-Elements complex modification to make macOS feel like Windows. macOS only (`macbook/`).

## Rule

Swap **Ctrl ↔ Cmd** globally (bidirectional, left + right):
- Ctrl now does everything Command did — `Ctrl+C/V/X`, `Ctrl+Space` (Spotlight), `Ctrl+Tab`, etc.
- The Cmd key sends a real Control.
- **Terminal exception**: swap is skipped when the frontmost app is Terminal / iTerm2 / Alacritty / kitty / WezTerm, so `Ctrl+C` still interrupts there.

Alt+Tab is handled by the **AltTab** app (Option+Tab, true per-window switcher) — not Karabiner.

## Apply

File is symlinked into `~/.config/karabiner/assets/complex_modifications/`; rule enabled in the active profile. Requires `brew install --cask karabiner-elements` and `brew install --cask alt-tab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)