### PR TITLE
feat(windows): port neovim config

### DIFF
--- a/windows/AppData/Local/nvim/init.lua
+++ b/windows/AppData/Local/nvim/init.lua
@@ -1,0 +1,5 @@
+-- Entry point. Keep this thin; real config lives under lua/config and lua/plugins.
+require("config.options")
+require("config.keymaps")
+require("config.autocmds")
+require("config.lazy")

--- a/windows/AppData/Local/nvim/lazy-lock.json
+++ b/windows/AppData/Local/nvim/lazy-lock.json
@@ -1,0 +1,17 @@
+{
+  "diffview.nvim": { "branch": "main", "commit": "4516612fe98ff56ae0415a259ff6361a89419b0a" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "mason-lspconfig.nvim": { "branch": "main", "commit": "a4068c3ebd4cb335b25239e5ea35c22ee6007962" },
+  "mason.nvim": { "branch": "main", "commit": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d" },
+  "neogit": { "branch": "master", "commit": "a0847c4bea5a5f92a36e3f3bf7da99d7d685d3ac" },
+  "nvim-lspconfig": { "branch": "master", "commit": "d5b6e3db4c17b0146f63a2fc47e2027a754b2cb1" },
+  "nvim-treesitter": { "branch": "master", "commit": "cf12346a3414fa1b06af75c79faebe7f76df080a" },
+  "nvim-web-devicons": { "branch": "master", "commit": "09d1324e264c6950262dbe02a9bce2933a6800db" },
+  "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
+  "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "render-markdown.nvim": { "branch": "main", "commit": "f422cb5c6855f150e2ddcfaf44e7157b98b34f6a" },
+  "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
+  "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
+  "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
+}

--- a/windows/AppData/Local/nvim/lua/config/autocmds.lua
+++ b/windows/AppData/Local/nvim/lua/config/autocmds.lua
@@ -1,0 +1,18 @@
+-- Autocommands. See :h autocmd
+local augroup = vim.api.nvim_create_augroup
+local autocmd = vim.api.nvim_create_autocmd
+
+-- Highlight on yank
+autocmd("TextYankPost", {
+  group = augroup("highlight_yank", { clear = true }),
+  callback = function()
+    vim.highlight.on_yank()
+  end,
+})
+
+-- Strip trailing whitespace on save
+autocmd("BufWritePre", {
+  group = augroup("trim_whitespace", { clear = true }),
+  pattern = "*",
+  command = [[%s/\s\+$//e]],
+})

--- a/windows/AppData/Local/nvim/lua/config/keymaps.lua
+++ b/windows/AppData/Local/nvim/lua/config/keymaps.lua
@@ -1,0 +1,38 @@
+-- Doom Emacs style keymaps: Space is leader, mnemonic prefix groups.
+-- Plugin-provided actions (find file, git, search) are mapped in their specs.
+local map = vim.keymap.set
+
+-- Clear search highlight
+map("n", "<Esc>", "<cmd>nohlsearch<CR>")
+
+-- Terminal: double-Esc leaves insert mode
+map("t", "<Esc><Esc>", "<C-\\><C-n>", { desc = "Exit terminal insert mode" })
+
+-- Move selected lines
+map("v", "J", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
+map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
+
+-- SPC w — window
+map("n", "<leader>ws", "<C-w>s", { desc = "Split window below" })
+map("n", "<leader>wv", "<C-w>v", { desc = "Split window right" })
+map("n", "<leader>wq", "<C-w>c", { desc = "Delete window" })
+map("n", "<leader>wo", "<C-w>o", { desc = "Delete other windows" })
+map("n", "<leader>wh", "<C-w>h", { desc = "Go to left window" })
+map("n", "<leader>wj", "<C-w>j", { desc = "Go to lower window" })
+map("n", "<leader>wk", "<C-w>k", { desc = "Go to upper window" })
+map("n", "<leader>wl", "<C-w>l", { desc = "Go to right window" })
+map("n", "<leader>w=", "<C-w>=", { desc = "Balance windows" })
+
+-- SPC b — buffer
+map("n", "<leader>bn", "<cmd>bnext<CR>", { desc = "Next buffer" })
+map("n", "<leader>bp", "<cmd>bprevious<CR>", { desc = "Previous buffer" })
+map("n", "<leader>bk", "<cmd>bdelete<CR>", { desc = "Kill buffer" })
+map("n", "<leader>bb", "<cmd>e #<CR>", { desc = "Switch to other buffer" })
+
+-- SPC f — file
+map("n", "<leader>fs", "<cmd>w<CR>", { desc = "Save file" })
+map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })
+
+-- SPC q — quit
+map("n", "<leader>qq", "<cmd>qa<CR>", { desc = "Quit Neovim" })
+map("n", "<leader>qQ", "<cmd>qa!<CR>", { desc = "Quit without saving" })

--- a/windows/AppData/Local/nvim/lua/config/lazy.lua
+++ b/windows/AppData/Local/nvim/lua/config/lazy.lua
@@ -1,0 +1,26 @@
+-- Bootstrap lazy.nvim (see https://lazy.folke.io/installation)
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Import every spec file under lua/plugins/
+require("lazy").setup({
+  spec = {
+    { import = "plugins" },
+  },
+  install = { colorscheme = { "habamax" } },
+  checker = { enabled = true, notify = false },
+  change_detection = { notify = false },
+})

--- a/windows/AppData/Local/nvim/lua/config/options.lua
+++ b/windows/AppData/Local/nvim/lua/config/options.lua
@@ -1,0 +1,25 @@
+-- Core editor options. See :h vim.opt
+local opt = vim.opt
+
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+opt.number = true
+opt.relativenumber = true
+opt.mouse = "a"
+opt.clipboard = "unnamedplus"
+
+opt.expandtab = true
+opt.shiftwidth = 2
+opt.tabstop = 2
+opt.smartindent = true
+
+opt.ignorecase = true
+opt.smartcase = true
+opt.wrap = false
+opt.signcolumn = "yes"
+opt.termguicolors = true
+opt.scrolloff = 8
+opt.splitright = true
+opt.splitbelow = true
+opt.undofile = true

--- a/windows/AppData/Local/nvim/lua/plugins/colorscheme.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/colorscheme.lua
@@ -1,0 +1,11 @@
+-- Colorscheme. priority high so it loads before other UI plugins.
+return {
+  "folke/tokyonight.nvim",
+  lazy = false,
+  priority = 1000,
+  opts = { style = "night" },
+  config = function(_, opts)
+    require("tokyonight").setup(opts)
+    vim.cmd.colorscheme("tokyonight")
+  end,
+}

--- a/windows/AppData/Local/nvim/lua/plugins/lsp.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/lsp.lua
@@ -22,18 +22,34 @@ return {
 
       -- jdtls's own JVM needs Java 21+. Projects may target older Java; only
       -- the server runtime is pinned here. Prefer $JDTLS_JAVA_HOME, else the
-      -- newest SDKMAN java >= 21. Nil = fall back to JAVA_HOME/PATH.
+      -- newest JDK >= 21 found in the OS's usual install dirs. Nil = fall back
+      -- to JAVA_HOME/PATH. Each candidate dir name carries its version
+      -- (jdk-21.0.5-hotspot, 21.0.2-open, corretto-21...), so major = first
+      -- number in the leaf name.
       local function jdtls_java_home()
         if vim.env.JDTLS_JAVA_HOME then
           return vim.env.JDTLS_JAVA_HOME
         end
-        local dirs = vim.fn.glob(vim.fn.expand("~/.sdkman/candidates/java") .. "/*", true, true)
+        local globs
+        if vim.fn.has("win32") == 1 then
+          globs = {
+            "C:/Program Files/Eclipse Adoptium/*",
+            "C:/Program Files/Java/*",
+            "C:/Program Files/Microsoft/*",
+            "C:/Program Files/Amazon Corretto/*",
+            "C:/Program Files/Zulu/*",
+          }
+        else
+          globs = { vim.fn.expand("~/.sdkman/candidates/java") .. "/*" }
+        end
         local best, best_major
-        for _, dir in ipairs(dirs) do
-          local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("^(%d+)"))
-          if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
-            if not best_major or major > best_major then
-              best, best_major = dir, major
+        for _, g in ipairs(globs) do
+          for _, dir in ipairs(vim.fn.glob(g, true, true)) do
+            local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("(%d+)"))
+            if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
+              if not best_major or major > best_major then
+                best, best_major = dir, major
+              end
             end
           end
         end

--- a/windows/AppData/Local/nvim/lua/plugins/lsp.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/lsp.lua
@@ -1,0 +1,63 @@
+-- LSP: mason installs language servers, nvim-lspconfig provides their configs.
+-- jdtls = Java. mason-lspconfig (v2) auto-enables installed servers.
+-- Keymaps live under SPC c (code) and bind per-buffer when an LSP attaches.
+return {
+  {
+    "williamboman/mason.nvim",
+    build = ":MasonUpdate",
+    opts = {},
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    event = { "BufReadPre", "BufNewFile" },
+    dependencies = {
+      "williamboman/mason.nvim",
+      "neovim/nvim-lspconfig",
+    },
+    opts = {
+      ensure_installed = { "jdtls" },
+    },
+    config = function(_, opts)
+      require("mason-lspconfig").setup(opts)
+
+      -- jdtls's own JVM needs Java 21+. Projects may target older Java; only
+      -- the server runtime is pinned here. Prefer $JDTLS_JAVA_HOME, else the
+      -- newest SDKMAN java >= 21. Nil = fall back to JAVA_HOME/PATH.
+      local function jdtls_java_home()
+        if vim.env.JDTLS_JAVA_HOME then
+          return vim.env.JDTLS_JAVA_HOME
+        end
+        local dirs = vim.fn.glob(vim.fn.expand("~/.sdkman/candidates/java") .. "/*", true, true)
+        local best, best_major
+        for _, dir in ipairs(dirs) do
+          local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("^(%d+)"))
+          if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
+            if not best_major or major > best_major then
+              best, best_major = dir, major
+            end
+          end
+        end
+        return best
+      end
+
+      local jhome = jdtls_java_home()
+      if jhome then
+        vim.lsp.config("jdtls", { cmd_env = { JAVA_HOME = jhome } })
+      end
+
+      vim.api.nvim_create_autocmd("LspAttach", {
+        desc = "LSP buffer-local keymaps",
+        callback = function(ev)
+          local function m(lhs, rhs, desc)
+            vim.keymap.set("n", lhs, rhs, { buffer = ev.buf, desc = desc })
+          end
+          m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
+          m("<leader>cD", vim.lsp.buf.references, "Find usages")
+          m("<leader>cf", function()
+            vim.lsp.buf.format({ async = true })
+          end, "Format buffer")
+        end,
+      })
+    end,
+  },
+}

--- a/windows/AppData/Local/nvim/lua/plugins/neogit.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/neogit.lua
@@ -1,0 +1,14 @@
+-- Neogit magit-style git UI. SPC g g = open (Doom style).
+return {
+  "NeogitOrg/neogit",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "sindrets/diffview.nvim",
+    "nvim-telescope/telescope.nvim",
+  },
+  cmd = "Neogit",
+  keys = {
+    { "<leader>gg", "<cmd>Neogit<CR>", desc = "Neogit status" },
+  },
+  opts = {},
+}

--- a/windows/AppData/Local/nvim/lua/plugins/oil.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/oil.lua
@@ -1,0 +1,12 @@
+-- oil.nvim: edit the filesystem like a buffer. SPC f f = open parent dir.
+return {
+  "stevearc/oil.nvim",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  lazy = false,
+  keys = {
+    { "<leader>ff", "<cmd>Oil<CR>", desc = "Open file explorer (oil)" },
+  },
+  opts = {
+    view_options = { show_hidden = true },
+  },
+}

--- a/windows/AppData/Local/nvim/lua/plugins/render-markdown.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/render-markdown.lua
@@ -1,0 +1,47 @@
+-- render-markdown: in-editor markdown rendering (headings, tables, code, lists,
+-- checkboxes) via treesitter. No browser, no external binary. SPC m = markdown.
+--   SPC m r  open current buffer as a rendered preview in a right vsplit (80%
+--            width); press again to close the preview split.
+-- The preview shows the SAME buffer, so edits on the left reflect live on the
+-- right. render-markdown conceals markup in every window showing the buffer, so
+-- the split reads as rendered output.
+local preview_win
+
+local function toggle_preview()
+  if preview_win and vim.api.nvim_win_is_valid(preview_win) then
+    vim.api.nvim_win_close(preview_win, false)
+    preview_win = nil
+    return
+  end
+  local buf = vim.api.nvim_get_current_buf()
+  if vim.bo[buf].filetype ~= "markdown" then
+    vim.notify("Not a markdown buffer", vim.log.levels.WARN)
+    return
+  end
+  vim.cmd("botright vsplit")
+  preview_win = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_buf(preview_win, buf)
+  vim.api.nvim_win_set_width(preview_win, math.floor(vim.o.columns * 0.8))
+end
+
+return {
+  "MeanderingProgrammer/render-markdown.nvim",
+  ft = { "markdown" },
+  dependencies = { "nvim-treesitter/nvim-treesitter" },
+  -- anti_conceal off: keep the cursor line rendered instead of revealing raw
+  -- markup. cursorline (markdown-only) marks where the cursor is instead.
+  init = function()
+    vim.api.nvim_create_autocmd("FileType", {
+      pattern = "markdown",
+      callback = function()
+        vim.opt_local.cursorline = true
+      end,
+    })
+  end,
+  opts = {
+    anti_conceal = { enabled = false },
+  },
+  keys = {
+    { "<leader>mr", toggle_preview, desc = "Markdown render preview (right 80%)" },
+  },
+}

--- a/windows/AppData/Local/nvim/lua/plugins/telescope.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/telescope.lua
@@ -1,0 +1,22 @@
+-- Telescope fuzzy finder. SPC SPC = find files (Doom style).
+return {
+  "nvim-telescope/telescope.nvim",
+  branch = "0.1.x",
+  dependencies = { "nvim-lua/plenary.nvim" },
+  cmd = "Telescope",
+  keys = {
+    { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
+    { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },
+    { "<leader>sp", "<cmd>Telescope live_grep<CR>", desc = "Search project text" },
+    { "<leader>sb", "<cmd>Telescope current_buffer_fuzzy_find<CR>", desc = "Search buffer" },
+    { "<leader>bi", "<cmd>Telescope buffers<CR>", desc = "Buffer list" },
+  },
+  opts = {
+    pickers = {
+      -- rg --files respects .gitignore; avoids `find` fallback that lists ignored files
+      find_files = {
+        find_command = { "rg", "--files", "--color", "never" },
+      },
+    },
+  },
+}

--- a/windows/AppData/Local/nvim/lua/plugins/toggleterm.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/toggleterm.lua
@@ -1,0 +1,73 @@
+-- toggleterm: terminals inside nvim. SPC t = terminal group.
+--   SPC t t  floating terminal, 80% of the screen, over the buffers
+--   SPC t s  bottom split, full width, pushes buffers up (30% height)
+--   SPC t v  right split, 30% width, pushes buffers left
+--   SPC t c  float 90%, runs claude code; toggle hides it (process stays alive)
+--   SPC t q  kill the active terminal, ending its process
+-- Distinct <count> per mapping = three independent, persistent terminals.
+
+-- Dedicated Claude Code terminal. Built once, reused so toggle hides/shows the
+-- same job instead of spawning a new one. close_on_exit=false keeps the buffer
+-- if claude quits. Rebuilt if it was killed (e.g. via SPC t q).
+local claude_term
+local function toggle_claude()
+  local tt = require("toggleterm.terminal")
+  if not claude_term or not tt.get(claude_term.id, true) then
+    claude_term = tt.Terminal:new({
+      cmd = "claude",
+      direction = "float",
+      close_on_exit = false,
+      float_opts = {
+        width = function()
+          return math.floor(vim.o.columns * 0.9)
+        end,
+        height = function()
+          return math.floor(vim.o.lines * 0.9)
+        end,
+      },
+    })
+  end
+  claude_term:toggle()
+end
+
+-- Kill the active terminal outright: shutdown() closes the window, wipes the
+-- buffer and stops the job. Prefer the focused terminal, else the last focused.
+local function kill_terminal()
+  local tt = require("toggleterm.terminal")
+  local id = tt.get_focused_id()
+  local term = (id and tt.get(id, true)) or tt.get_last_focused()
+  if term then
+    term:shutdown()
+  else
+    vim.notify("No active toggleterm terminal", vim.log.levels.WARN)
+  end
+end
+
+return {
+  "akinsho/toggleterm.nvim",
+  version = "*",
+  opts = {
+    size = function(term)
+      if term.direction == "horizontal" then
+        return math.floor(vim.o.lines * 0.3)
+      elseif term.direction == "vertical" then
+        return math.floor(vim.o.columns * 0.3)
+      end
+    end,
+    float_opts = {
+      width = function()
+        return math.floor(vim.o.columns * 0.8)
+      end,
+      height = function()
+        return math.floor(vim.o.lines * 0.8)
+      end,
+    },
+  },
+  keys = {
+    { "<leader>tt", "<cmd>1ToggleTerm direction=float<cr>", desc = "Terminal (float 80%)" },
+    { "<leader>ts", "<cmd>2ToggleTerm direction=horizontal<cr>", desc = "Terminal (bottom split)" },
+    { "<leader>tv", "<cmd>3ToggleTerm direction=vertical<cr>", desc = "Terminal (right split)" },
+    { "<leader>tc", toggle_claude, desc = "Terminal (Claude Code, 90%)" },
+    { "<leader>tq", kill_terminal, desc = "Kill active terminal" },
+  },
+}

--- a/windows/AppData/Local/nvim/lua/plugins/treesitter.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/treesitter.lua
@@ -1,0 +1,15 @@
+-- nvim-treesitter: syntax highlighting via tree-sitter parsers.
+return {
+  "nvim-treesitter/nvim-treesitter",
+  branch = "master",
+  build = ":TSUpdate",
+  event = { "BufReadPost", "BufNewFile" },
+  opts = {
+    ensure_installed = { "java", "lua", "markdown", "markdown_inline", "vim", "vimdoc" },
+    highlight = { enable = true },
+    indent = { enable = true },
+  },
+  config = function(_, opts)
+    require("nvim-treesitter.configs").setup(opts)
+  end,
+}

--- a/windows/AppData/Local/nvim/lua/plugins/which-key.lua
+++ b/windows/AppData/Local/nvim/lua/plugins/which-key.lua
@@ -1,0 +1,29 @@
+-- which-key: shows the Doom-style leader prefix groups as you type Space.
+return {
+  "folke/which-key.nvim",
+  event = "VeryLazy",
+  opts = {
+    preset = "helix",
+    spec = {
+      { "<leader>b", group = "buffer" },
+      { "<leader>c", group = "code" },
+      { "<leader>f", group = "file" },
+      { "<leader>g", group = "git" },
+      { "<leader>m", group = "markdown" },
+      { "<leader>p", group = "project" },
+      { "<leader>q", group = "quit" },
+      { "<leader>s", group = "search" },
+      { "<leader>t", group = "terminal" },
+      { "<leader>w", group = "window" },
+    },
+  },
+  keys = {
+    {
+      "<leader>?",
+      function()
+        require("which-key").show({ global = false })
+      end,
+      desc = "Buffer local keymaps",
+    },
+  },
+}


### PR DESCRIPTION
## What

New `windows/` platform dir. Neovim config ported to `windows/AppData/Local/nvim` (`%LOCALAPPDATA%\nvim`).

## How

- **Copy first** (`bb0b45c`): verbatim copy of `macbook/.config/nvim`, byte-identical.
- **Port** (`b3fc24d`): only platform-specific code was `lsp.lua` jdtls Java detection. Made it OS-aware — Windows scans standard JDK install dirs (Eclipse Adoptium / Java / Microsoft / Amazon Corretto / Zulu) for the newest JDK >= 21; non-Windows keeps the SDKMAN scan. `$JDTLS_JAVA_HOME` still overrides. Everything else is cross-platform Lua, unchanged.

## Verified

All 14 Lua files parse clean under nvim. Java detection tested: non-Windows branch still resolves SDKMAN java 25; version regex handles both `21.0.2-open` and `jdk-21.0.5-hotspot` naming.

## Runtime deps on Windows (install-time, not config)

- Neovim, git, a C compiler for `:TSUpdate` (zig/MSVC/gcc)
- `ripgrep` (telescope find_files + live_grep)
- `jdtls` auto-installs via mason; needs a JDK 21+ discoverable as above
- `claude` on PATH for the SPC t c terminal

Note: nvim's default shell on Windows is `cmd.exe`; toggleterm terminals open there. Say the word if you want a PowerShell override guarded by `has('win32')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)