### PR TITLE
fix(nvim): sync linux config to macbook

### DIFF
--- a/linux/.config/nvim/lua/config/keymaps.lua
+++ b/linux/.config/nvim/lua/config/keymaps.lua
@@ -15,7 +15,7 @@ map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
 -- SPC w — window
 map("n", "<leader>ws", "<C-w>s", { desc = "Split window below" })
 map("n", "<leader>wv", "<C-w>v", { desc = "Split window right" })
-map("n", "<leader>wd", "<C-w>c", { desc = "Delete window" })
+map("n", "<leader>wq", "<C-w>c", { desc = "Delete window" })
 map("n", "<leader>wo", "<C-w>o", { desc = "Delete other windows" })
 map("n", "<leader>wh", "<C-w>h", { desc = "Go to left window" })
 map("n", "<leader>wj", "<C-w>j", { desc = "Go to lower window" })
@@ -26,7 +26,7 @@ map("n", "<leader>w=", "<C-w>=", { desc = "Balance windows" })
 -- SPC b — buffer
 map("n", "<leader>bn", "<cmd>bnext<CR>", { desc = "Next buffer" })
 map("n", "<leader>bp", "<cmd>bprevious<CR>", { desc = "Previous buffer" })
-map("n", "<leader>bd", "<cmd>bdelete<CR>", { desc = "Kill buffer" })
+map("n", "<leader>bk", "<cmd>bdelete<CR>", { desc = "Kill buffer" })
 map("n", "<leader>bb", "<cmd>e #<CR>", { desc = "Switch to other buffer" })
 
 -- SPC f — file

--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -7,9 +7,16 @@ return {
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
     { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },
-    { "<leader>sg", "<cmd>Telescope live_grep<CR>", desc = "Grep project" },
+    { "<leader>sp", "<cmd>Telescope live_grep<CR>", desc = "Search project text" },
     { "<leader>sb", "<cmd>Telescope current_buffer_fuzzy_find<CR>", desc = "Search buffer" },
     { "<leader>bi", "<cmd>Telescope buffers<CR>", desc = "Buffer list" },
   },
-  opts = {},
+  opts = {
+    pickers = {
+      -- rg --files respects .gitignore; avoids `find` fallback that lists ignored files
+      find_files = {
+        find_command = { "rg", "--files", "--color", "never" },
+      },
+    },
+  },
 }


### PR DESCRIPTION
## What

Bring `linux/.config/nvim` to full parity with `macbook/.config/nvim` (the current mac setup).

## Why

For running Neovim inside WSL Ubuntu, the `linux/` config is what applies. It had drifted from the newer mac config, so WSL would not match the mac setup.

## How

Synced the two drifted files to macbook:
- keymaps: `<leader>wq` delete window, `<leader>bk` kill buffer
- telescope: `<leader>sp` live_grep, plus `rg --files` find_command opts

Now `linux/.config/nvim` is byte-identical to `macbook/.config/nvim` (excluding the per-machine lazy-lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)