### PR TITLE
feat(nvim): projects as tabs

### DIFF
--- a/linux/.config/nvim/lua/plugins/project.lua
+++ b/linux/.config/nvim/lua/plugins/project.lua
@@ -1,0 +1,79 @@
+-- project.nvim: track project roots; open each project as its own tab.
+-- One project per tabpage, each with a tab-local cwd (:tcd).
+--   SPC p o  pick a known project -> opens in a NEW tab (oil at its root)
+--   SPC p q  close the current project (tabpage)
+--   Alt+1..9 switch to project (tab) N
+-- SPC p group is declared in which-key ("project").
+return {
+  "ahmedkhalf/project.nvim",
+  event = "VeryLazy",
+  dependencies = { "nvim-telescope/telescope.nvim" },
+  config = function()
+    -- main module is "project_nvim" despite the repo name.
+    require("project_nvim").setup({
+      -- keep auto-cd tab-local so each project tab holds its own cwd
+      scope_chdir = "tab",
+      detection_methods = { "pattern", "lsp" },
+      patterns = {
+        ".git",
+        "package.json",
+        "Cargo.toml",
+        "go.mod",
+        "pom.xml",
+        "build.gradle",
+        "settings.gradle",
+        ".root",
+      },
+    })
+
+    -- Open a folder as a project: new tab, tab-local cwd, oil at the root.
+    local function open_project_in_tab(path)
+      if not path or path == "" then
+        return
+      end
+      vim.cmd("tabnew")
+      vim.cmd("tcd " .. vim.fn.fnameescape(path))
+      require("oil").open(path)
+    end
+
+    -- Telescope picker of recent projects (most recent first); the chosen
+    -- project opens in a new tab.
+    local function pick_project()
+      local recents = require("project_nvim").get_recent_projects()
+      local items = {}
+      for i = #recents, 1, -1 do
+        table.insert(items, recents[i])
+      end
+      if vim.tbl_isempty(items) then
+        vim.notify("No known projects yet (visit a project root first)", vim.log.levels.INFO)
+        return
+      end
+      local pickers = require("telescope.pickers")
+      local finders = require("telescope.finders")
+      local conf = require("telescope.config").values
+      local actions = require("telescope.actions")
+      local action_state = require("telescope.actions.state")
+      pickers
+        .new({}, {
+          prompt_title = "Projects",
+          finder = finders.new_table({ results = items }),
+          sorter = conf.generic_sorter({}),
+          attach_mappings = function(bufnr)
+            actions.select_default:replace(function()
+              actions.close(bufnr)
+              local entry = action_state.get_selected_entry()
+              open_project_in_tab(entry and entry[1])
+            end)
+            return true
+          end,
+        })
+        :find()
+    end
+
+    vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
+    vim.keymap.set("n", "<leader>pq", "<cmd>tabclose<CR>", { desc = "Close project (tab)" })
+    for i = 1, 9 do
+      vim.keymap.set("n", ("<A-%d>"):format(i), ("%dgt"):format(i), { desc = "Go to project " .. i })
+    end
+  end,
+}

--- a/macbook/.config/nvim/lazy-lock.json
+++ b/macbook/.config/nvim/lazy-lock.json
@@ -9,6 +9,7 @@
   "nvim-web-devicons": { "branch": "master", "commit": "09d1324e264c6950262dbe02a9bce2933a6800db" },
   "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "project.nvim": { "branch": "main", "commit": "8c6bad7d22eef1b71144b401c9f74ed01526a4fb" },
   "render-markdown.nvim": { "branch": "main", "commit": "f422cb5c6855f150e2ddcfaf44e7157b98b34f6a" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
   "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },

--- a/macbook/.config/nvim/lua/plugins/project.lua
+++ b/macbook/.config/nvim/lua/plugins/project.lua
@@ -1,0 +1,79 @@
+-- project.nvim: track project roots; open each project as its own tab.
+-- One project per tabpage, each with a tab-local cwd (:tcd).
+--   SPC p o  pick a known project -> opens in a NEW tab (oil at its root)
+--   SPC p q  close the current project (tabpage)
+--   Alt+1..9 switch to project (tab) N
+-- SPC p group is declared in which-key ("project").
+return {
+  "ahmedkhalf/project.nvim",
+  event = "VeryLazy",
+  dependencies = { "nvim-telescope/telescope.nvim" },
+  config = function()
+    -- main module is "project_nvim" despite the repo name.
+    require("project_nvim").setup({
+      -- keep auto-cd tab-local so each project tab holds its own cwd
+      scope_chdir = "tab",
+      detection_methods = { "pattern", "lsp" },
+      patterns = {
+        ".git",
+        "package.json",
+        "Cargo.toml",
+        "go.mod",
+        "pom.xml",
+        "build.gradle",
+        "settings.gradle",
+        ".root",
+      },
+    })
+
+    -- Open a folder as a project: new tab, tab-local cwd, oil at the root.
+    local function open_project_in_tab(path)
+      if not path or path == "" then
+        return
+      end
+      vim.cmd("tabnew")
+      vim.cmd("tcd " .. vim.fn.fnameescape(path))
+      require("oil").open(path)
+    end
+
+    -- Telescope picker of recent projects (most recent first); the chosen
+    -- project opens in a new tab.
+    local function pick_project()
+      local recents = require("project_nvim").get_recent_projects()
+      local items = {}
+      for i = #recents, 1, -1 do
+        table.insert(items, recents[i])
+      end
+      if vim.tbl_isempty(items) then
+        vim.notify("No known projects yet (visit a project root first)", vim.log.levels.INFO)
+        return
+      end
+      local pickers = require("telescope.pickers")
+      local finders = require("telescope.finders")
+      local conf = require("telescope.config").values
+      local actions = require("telescope.actions")
+      local action_state = require("telescope.actions.state")
+      pickers
+        .new({}, {
+          prompt_title = "Projects",
+          finder = finders.new_table({ results = items }),
+          sorter = conf.generic_sorter({}),
+          attach_mappings = function(bufnr)
+            actions.select_default:replace(function()
+              actions.close(bufnr)
+              local entry = action_state.get_selected_entry()
+              open_project_in_tab(entry and entry[1])
+            end)
+            return true
+          end,
+        })
+        :find()
+    end
+
+    vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
+    vim.keymap.set("n", "<leader>pq", "<cmd>tabclose<CR>", { desc = "Close project (tab)" })
+    for i = 1, 9 do
+      vim.keymap.set("n", ("<A-%d>"):format(i), ("%dgt"):format(i), { desc = "Go to project " .. i })
+    end
+  end,
+}


### PR DESCRIPTION
## What

Open folders as projects, one project per tab, via project.nvim + a thin custom layer.

## Keybindings (SPC p = project group)

- `SPC p o` — telescope picker of known/recent projects; the choice opens in a **new tab** (`tcd` to its root, oil file browser shown)
- `SPC p q` — close the current project (`tabclose`)
- `Alt+1..9` — switch to project (tab) N

## How

- **project.nvim** tracks project roots (git / package.json / go.mod / pom.xml / build.gradle / etc.) and keeps the recent-projects history that `SPC p o` lists.
- `scope_chdir = "tab"` so its auto-cd is tab-local — each project tab keeps its own cwd, no global-cwd fighting.
- Custom `pick_project` builds a telescope picker from `get_recent_projects()` and opens the selection in a fresh tab.

## Verified

Headless: keymaps bind (`po`→picker fn, `pq`→tabclose, `A-1`→`1gt`), `get_recent_projects` API present, and new-tab + tab-local cwd + oil confirmed (opened `~/dev/optimizer/workspace-1` as tab 2 with its own cwd).

macbook + linux both.

Note: `Alt+<num>` needs the terminal to send Alt/Meta (Windows Terminal/WSL fine; macOS terminals may need “use Option as Meta”).

🤖 Generated with [Claude Code](https://claude.com/claude-code)