### PR TITLE
feat(linux): setup script + zshrc

### DIFF
--- a/linux/.zshrc
+++ b/linux/.zshrc
@@ -1,0 +1,128 @@
+# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
+# Initialization code that may require console input (password prompts, [y/n]
+# confirmations, etc.) must go above this block; everything else may go below.
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
+# If you come from bash you might have to change your $PATH.
+# export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
+
+# Path to your Oh My Zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# Set name of the theme to load --- if set to "random", it will
+# load a random theme each time Oh My Zsh is loaded, in which case,
+# to know which specific one was loaded, run: echo $RANDOM_THEME
+# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
+ZSH_THEME="powerlevel10k/powerlevel10k"
+
+# Set list of themes to pick from when loading at random
+# Setting this variable when ZSH_THEME=random will cause zsh to load
+# a theme from this variable instead of looking in $ZSH/themes/
+# If set to an empty array, this variable will have no effect.
+# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
+
+# Uncomment the following line to use case-sensitive completion.
+# CASE_SENSITIVE="true"
+
+# Uncomment the following line to use hyphen-insensitive completion.
+# Case-sensitive completion must be off. _ and - will be interchangeable.
+# HYPHEN_INSENSITIVE="true"
+
+# Uncomment one of the following lines to change the auto-update behavior
+# zstyle ':omz:update' mode disabled  # disable automatic updates
+# zstyle ':omz:update' mode auto      # update automatically without asking
+# zstyle ':omz:update' mode reminder  # just remind me to update when it's time
+
+# Uncomment the following line to change how often to auto-update (in days).
+# zstyle ':omz:update' frequency 13
+
+# Uncomment the following line if pasting URLs and other text is messed up.
+# DISABLE_MAGIC_FUNCTIONS="true"
+
+# Uncomment the following line to disable colors in ls.
+# DISABLE_LS_COLORS="true"
+
+# Uncomment the following line to disable auto-setting terminal title.
+# DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to enable command auto-correction.
+# ENABLE_CORRECTION="true"
+
+# Uncomment the following line to display red dots whilst waiting for completion.
+# You can also set it to another string to have that shown instead of the default red dots.
+# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
+# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
+# COMPLETION_WAITING_DOTS="true"
+
+# Uncomment the following line if you want to disable marking untracked files
+# under VCS as dirty. This makes repository status check for large repositories
+# much, much faster.
+# DISABLE_UNTRACKED_FILES_DIRTY="true"
+
+# Uncomment the following line if you want to change the command execution time
+# stamp shown in the history command output.
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
+# HIST_STAMPS="mm/dd/yyyy"
+
+# Would you like to use another custom folder than $ZSH/custom?
+# ZSH_CUSTOM=/path/to/new-custom-folder
+
+# Which plugins would you like to load?
+# Standard plugins can be found in $ZSH/plugins/
+# Custom plugins may be added to $ZSH_CUSTOM/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
+plugins=()
+
+source $ZSH/oh-my-zsh.sh
+
+# User configuration
+
+# export MANPATH="/usr/local/man:$MANPATH"
+
+# You may need to manually set your language environment
+# export LANG=en_US.UTF-8
+
+# Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='nvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch $(uname -m)"
+
+# Set personal aliases, overriding those provided by Oh My Zsh libs,
+# plugins, and themes. Aliases can be placed here, though Oh My Zsh
+# users are encouraged to define aliases within a top-level file in
+# the $ZSH_CUSTOM folder, with .zsh extension. Examples:
+# - $ZSH_CUSTOM/aliases.zsh
+# - $ZSH_CUSTOM/macos.zsh
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
+[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+export PATH="$HOME/.local/bin:$PATH"
+
+#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
+export SDKMAN_DIR="$HOME/.sdkman"
+[[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+
+# Add JBang to environment
+alias j!=jbang
+export PATH="$HOME/.jbang/bin:$PATH"

--- a/linux/scripts/setup-full.sh
+++ b/linux/scripts/setup-full.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Wire the Linux setup: install zsh (+ the bits the .zshrc needs), back up any
+# existing zsh / p10k / nvim config, then symlink this repo's files into place.
+# Idempotent: safe to re-run. Existing real files are moved to <file>.backup.<ts>.
+set -euo pipefail
+
+DOTFILES_DIR="${HOME}/.dotfiles"
+PLATFORM_DIR="${DOTFILES_DIR}/linux"
+TS="$(date +%Y%m%d%H%M%S)"
+
+log() { printf '%s\n' "$*"; }
+
+# --- packages: zsh, plus git/curl needed to fetch oh-my-zsh + powerlevel10k ---
+install_packages() {
+  if command -v zsh >/dev/null 2>&1 \
+    && command -v git >/dev/null 2>&1 \
+    && command -v curl >/dev/null 2>&1; then
+    log "packages: zsh, git, curl already present"
+    return
+  fi
+  log "packages: installing zsh git curl..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update && sudo apt-get install -y zsh git curl
+  elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y zsh git curl
+  elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --noconfirm zsh git curl
+  elif command -v zypper >/dev/null 2>&1; then
+    sudo zypper install -y zsh git curl
+  else
+    log "packages: no known package manager (apt/dnf/pacman/zypper); install zsh git curl manually" >&2
+    exit 1
+  fi
+}
+
+# --- oh-my-zsh + powerlevel10k: dependencies of the symlinked .zshrc ---
+install_zsh_framework() {
+  if [ -d "${HOME}/.oh-my-zsh" ]; then
+    log "oh-my-zsh: already present"
+  else
+    log "oh-my-zsh: installing (keeping our .zshrc, not switching shell)..."
+    # KEEP_ZSHRC so the installer does not overwrite the .zshrc we symlink below.
+    RUNZSH=no CHSH=no KEEP_ZSHRC=yes \
+      sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+  fi
+
+  local p10k_dir="${ZSH_CUSTOM:-${HOME}/.oh-my-zsh/custom}/themes/powerlevel10k"
+  if [ -d "${p10k_dir}" ]; then
+    log "powerlevel10k: already present"
+  else
+    log "powerlevel10k: cloning..."
+    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "${p10k_dir}"
+  fi
+}
+
+# --- backup any existing target, then symlink src -> dst ---
+backup_and_link() {
+  local src="$1" dst="$2"
+  if [ ! -e "${src}" ]; then
+    log "skip: source missing ${src}" >&2
+    return
+  fi
+  if [ -L "${dst}" ] && [ "$(readlink "${dst}")" = "${src}" ]; then
+    log "link ok: ${dst} -> ${src}"
+    return
+  fi
+  mkdir -p "$(dirname "${dst}")"
+  if [ -e "${dst}" ] || [ -L "${dst}" ]; then
+    local backup="${dst}.backup.${TS}"
+    log "backup: ${dst} -> ${backup}"
+    mv "${dst}" "${backup}"
+  fi
+  ln -s "${src}" "${dst}"
+  log "linked: ${dst} -> ${src}"
+}
+
+main() {
+  install_packages
+  install_zsh_framework
+
+  backup_and_link "${PLATFORM_DIR}/.zshrc"       "${HOME}/.zshrc"
+  backup_and_link "${PLATFORM_DIR}/.p10k.zsh"    "${HOME}/.p10k.zsh"
+  backup_and_link "${PLATFORM_DIR}/.config/nvim" "${HOME}/.config/nvim"
+
+  local zsh_bin
+  zsh_bin="$(command -v zsh)"
+  if [ "${SHELL:-}" != "${zsh_bin}" ]; then
+    log ""
+    log "note: default shell is '${SHELL:-unknown}'. To make zsh the default:"
+    log "  chsh -s ${zsh_bin}"
+    log "(left to you: chsh prompts for your password / needs a re-login.)"
+  fi
+  log ""
+  log "done. open a new zsh session to load the setup."
+}
+
+main "$@"


### PR DESCRIPTION
## What

Linux bootstrap: `linux/scripts/setup-full.sh` to wire the setup, plus the missing `linux/.zshrc`.

## How

Script steps (idempotent, safe to re-run):
1. **Install packages** — `zsh` (plus `git`/`curl`, needed to fetch the framework) via apt/dnf/pacman/zypper.
2. **Install zsh framework** — oh-my-zsh + powerlevel10k, since the symlinked `.zshrc` sources them (installing bare zsh would leave a broken shell). `KEEP_ZSHRC=yes` so the installer never clobbers our `.zshrc`.
3. **Backup + symlink** — for each of `.zshrc`, `.p10k.zsh`, `.config/nvim`: if a real file/dir already lives at the target it's moved to `<file>.backup.<timestamp>`, then the repo file is symlinked in.

`linux/.zshrc` is added from `macbook/.zshrc` (cross-platform: oh-my-zsh / p10k / sdkman / nvm / jbang).

Default-shell switch (`chsh`) is left as a printed note rather than run automatically — it needs the user's password / a re-login.

## Verified

`bash -n` clean. `backup_and_link` sandbox-tested: real file backed up before linking, re-run idempotent (no duplicate backup), wrong-target symlink relinked, nested target dir auto-created, missing source skipped without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)