### PR TITLE
feat(nvim): add blink.cmp autocomplete (ctrl+space)

### DIFF
--- a/linux/.config/nvim/lua/plugins/blink.lua
+++ b/linux/.config/nvim/lua/plugins/blink.lua
@@ -1,0 +1,20 @@
+-- Completion menu. blink.cmp renders the popup; the LSP (jdtls for Java, etc.)
+-- supplies the items. In insert mode Ctrl+Space opens the menu, C-n/C-p move,
+-- Enter accepts. Capabilities are registered with the LSP in lsp.lua.
+return {
+  "saghen/blink.cmp",
+  version = "1.*", -- released tag ships the prebuilt fuzzy-matcher binary
+  event = "InsertEnter",
+  opts = {
+    keymap = {
+      preset = "default", -- <C-space> shows menu/docs; <C-n>/<C-p> navigate
+      ["<CR>"] = { "accept", "fallback" }, -- Enter accepts the selection
+    },
+    sources = {
+      default = { "lsp", "path", "snippets", "buffer" },
+    },
+    completion = {
+      documentation = { auto_show = true },
+    },
+  },
+}

--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -20,6 +20,13 @@ return {
     config = function(_, opts)
       require("mason-lspconfig").setup(opts)
 
+      -- Advertise blink.cmp's completion capabilities to every server so the
+      -- LSP returns snippets and resolvable detail. Applied before servers
+      -- attach (BufReadPre), which is why it lives here, not in blink's spec.
+      vim.lsp.config("*", {
+        capabilities = require("blink.cmp").get_lsp_capabilities(),
+      })
+
       -- jdtls's own JVM needs Java 21+. Projects may target older Java; only
       -- the server runtime is pinned here. Prefer $JDTLS_JAVA_HOME, else the
       -- newest SDKMAN java >= 21. Nil = fall back to JAVA_HOME/PATH.

--- a/macbook/.config/nvim/lua/plugins/blink.lua
+++ b/macbook/.config/nvim/lua/plugins/blink.lua
@@ -1,0 +1,20 @@
+-- Completion menu. blink.cmp renders the popup; the LSP (jdtls for Java, etc.)
+-- supplies the items. In insert mode Ctrl+Space opens the menu, C-n/C-p move,
+-- Enter accepts. Capabilities are registered with the LSP in lsp.lua.
+return {
+  "saghen/blink.cmp",
+  version = "1.*", -- released tag ships the prebuilt fuzzy-matcher binary
+  event = "InsertEnter",
+  opts = {
+    keymap = {
+      preset = "default", -- <C-space> shows menu/docs; <C-n>/<C-p> navigate
+      ["<CR>"] = { "accept", "fallback" }, -- Enter accepts the selection
+    },
+    sources = {
+      default = { "lsp", "path", "snippets", "buffer" },
+    },
+    completion = {
+      documentation = { auto_show = true },
+    },
+  },
+}

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -20,6 +20,13 @@ return {
     config = function(_, opts)
       require("mason-lspconfig").setup(opts)
 
+      -- Advertise blink.cmp's completion capabilities to every server so the
+      -- LSP returns snippets and resolvable detail. Applied before servers
+      -- attach (BufReadPre), which is why it lives here, not in blink's spec.
+      vim.lsp.config("*", {
+        capabilities = require("blink.cmp").get_lsp_capabilities(),
+      })
+
       -- jdtls's own JVM needs Java 21+. Projects may target older Java; only
       -- the server runtime is pinned here. Prefer $JDTLS_JAVA_HOME, else the
       -- newest SDKMAN java >= 21. Nil = fall back to JAVA_HOME/PATH.


### PR DESCRIPTION
## what

add blink.cmp so nvim show autocomplete popup. lsp already give word (jdtls for java). before, no popup engine, so no complete.

## how use

- insert mode only
- **ctrl+space** = open menu
- **ctrl+n / ctrl+p** = move pick
- **enter** = take pick

## files

- new `blink.lua` (mac + linux) — plugin spec, keymap, sources (lsp, path, snippet, buffer)
- `lsp.lua` (mac + linux) — tell every lsp about blink complete power, before server attach

## note

lazy pull prebuilt fuzzy binary (tag `1.*`), no rust need. restart nvim to install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)