### PR TITLE
feat(nvim): blink 2s delay, tab accept, enter newline

### DIFF
--- a/linux/.config/nvim/lua/plugins/blink.lua
+++ b/linux/.config/nvim/lua/plugins/blink.lua
@@ -8,12 +8,14 @@ return {
   opts = {
     keymap = {
       preset = "default", -- <C-space> shows menu/docs; <C-n>/<C-p> navigate
-      ["<CR>"] = { "accept", "fallback" }, -- Enter accepts the selection
+      ["<Tab>"] = { "accept", "fallback" }, -- Tab applies the selection
+      ["<CR>"] = { "fallback" }, -- Enter never accepts: closes menu + new line
     },
     sources = {
       default = { "lsp", "path", "snippets", "buffer" },
     },
     completion = {
+      menu = { auto_show_delay_ms = 2000 }, -- wait 2s before auto-opening menu
       documentation = { auto_show = true },
     },
   },

--- a/macbook/.config/nvim/lua/plugins/blink.lua
+++ b/macbook/.config/nvim/lua/plugins/blink.lua
@@ -8,12 +8,14 @@ return {
   opts = {
     keymap = {
       preset = "default", -- <C-space> shows menu/docs; <C-n>/<C-p> navigate
-      ["<CR>"] = { "accept", "fallback" }, -- Enter accepts the selection
+      ["<Tab>"] = { "accept", "fallback" }, -- Tab applies the selection
+      ["<CR>"] = { "fallback" }, -- Enter never accepts: closes menu + new line
     },
     sources = {
       default = { "lsp", "path", "snippets", "buffer" },
     },
     completion = {
+      menu = { auto_show_delay_ms = 2000 }, -- wait 2s before auto-opening menu
       documentation = { auto_show = true },
     },
   },


### PR DESCRIPTION
## what

follow-up tweak for blink.cmp. first blink pr (#16) merge but only give base commit, this tweak get lost. now land it clean.

## change

- blink wait **2s** before auto pop menu (`auto_show_delay_ms = 2000`). ctrl+space still pop now, no wait.
- **tab** take pick (apply selection)
- **enter** no take pick. just close menu and make new line.

mac + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)