### PR TITLE
feat(nvim): neo-tree project sidebar (SPC o p)

### DIFF
--- a/linux/.config/nvim/lua/plugins/neo-tree.lua
+++ b/linux/.config/nvim/lua/plugins/neo-tree.lua
@@ -1,0 +1,24 @@
+-- neo-tree: project files as a tree in a left sidebar. SPC o p toggles it
+-- (Doom "open project sidebar"). Icons come from nvim-web-devicons, already
+-- pulled in by oil. netrw hijack is disabled so oil stays the dir editor.
+return {
+  "nvim-neo-tree/neo-tree.nvim",
+  branch = "v3.x",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "MunifTanjim/nui.nvim",
+    "nvim-tree/nvim-web-devicons",
+  },
+  cmd = "Neotree",
+  keys = {
+    { "<leader>op", "<cmd>Neotree toggle<CR>", desc = "Project tree" },
+  },
+  opts = {
+    window = { position = "left" },
+    filesystem = {
+      follow_current_file = { enabled = true }, -- track the active buffer
+      use_libuv_file_watcher = true, -- live-refresh on external file changes
+      hijack_netrw_behavior = "disabled", -- leave netrw/dirs to oil
+    },
+  },
+}

--- a/linux/.config/nvim/lua/plugins/which-key.lua
+++ b/linux/.config/nvim/lua/plugins/which-key.lua
@@ -10,6 +10,7 @@ return {
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
       { "<leader>m", group = "markdown" },
+      { "<leader>o", group = "open" },
       { "<leader>p", group = "project" },
       { "<leader>q", group = "quit" },
       { "<leader>s", group = "search" },

--- a/macbook/.config/nvim/lua/plugins/neo-tree.lua
+++ b/macbook/.config/nvim/lua/plugins/neo-tree.lua
@@ -1,0 +1,24 @@
+-- neo-tree: project files as a tree in a left sidebar. SPC o p toggles it
+-- (Doom "open project sidebar"). Icons come from nvim-web-devicons, already
+-- pulled in by oil. netrw hijack is disabled so oil stays the dir editor.
+return {
+  "nvim-neo-tree/neo-tree.nvim",
+  branch = "v3.x",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "MunifTanjim/nui.nvim",
+    "nvim-tree/nvim-web-devicons",
+  },
+  cmd = "Neotree",
+  keys = {
+    { "<leader>op", "<cmd>Neotree toggle<CR>", desc = "Project tree" },
+  },
+  opts = {
+    window = { position = "left" },
+    filesystem = {
+      follow_current_file = { enabled = true }, -- track the active buffer
+      use_libuv_file_watcher = true, -- live-refresh on external file changes
+      hijack_netrw_behavior = "disabled", -- leave netrw/dirs to oil
+    },
+  },
+}

--- a/macbook/.config/nvim/lua/plugins/which-key.lua
+++ b/macbook/.config/nvim/lua/plugins/which-key.lua
@@ -10,6 +10,7 @@ return {
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
       { "<leader>m", group = "markdown" },
+      { "<leader>o", group = "open" },
       { "<leader>p", group = "project" },
       { "<leader>q", group = "quit" },
       { "<leader>s", group = "search" },


### PR DESCRIPTION
## what

add neo-tree file explorer. show project as tree in **left panel**. this what user want ("project as tree", left side).

note: treesitter is syntax parser, not file tree. real tool for tree panel = neo-tree.

## key

- **SPC o p** = toggle project tree (left)
- new **SPC o** "open" group in which-key

## careful

- netrw hijack **disabled** so oil still own dir edit. no fight.
- icon from nvim-web-devicons (oil already pull it, need nerd font)

mac + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)