### PR TITLE
feat(nvim): relative-line jump lu/ld

### DIFF
--- a/linux/.config/nvim/lua/config/keymaps.lua
+++ b/linux/.config/nvim/lua/config/keymaps.lua
@@ -36,3 +36,67 @@ map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })
 -- SPC q — quit
 map("n", "<leader>qq", "<cmd>qa<CR>", { desc = "Quit Neovim" })
 map("n", "<leader>qQ", "<cmd>qa!<CR>", { desc = "Quit without saving" })
+
+-- Relative-line jump: type the count AFTER the prefix (relativenumber shows it).
+--   lu<count>  jump <count> lines up      (== <count>k)
+--   ld<count>  jump <count> lines down    (== <count>j)
+-- The count is read live: fast-typed digits (lu52) are drained from the input
+-- queue, so no terminator key is needed; a pause commits (lu5 then jump). Esc
+-- cancels; a non-digit is replayed so no keystroke is lost.
+--
+-- read_relative_count is pure (input comes only from `next_char`) so it can be
+-- unit-tested. next_char(true) blocks for the first key; next_char(false)
+-- returns the next already-queued char or nil.
+local function read_relative_count(next_char)
+  local first = next_char(true)
+  if first == nil or first == "\27" then -- nothing / Esc: cancel
+    return nil
+  end
+  if not first:match("^%d$") then
+    vim.api.nvim_feedkeys(first, "n", false) -- not a number: replay, abort
+    return nil
+  end
+  local digits = first
+  while true do
+    local c = next_char(false) -- only chars already queued (fast typing)
+    if c == nil then
+      break
+    elseif c:match("^%d$") then
+      digits = digits .. c
+    else
+      vim.api.nvim_feedkeys(c, "n", false) -- non-digit: replay, stop
+      break
+    end
+  end
+  return tonumber(digits)
+end
+
+-- Default reader: blocking getcharstr for the first key, non-blocking getchar
+-- for the rest of the queue.
+local function getchar_reader(blocking)
+  if blocking then
+    return vim.fn.getcharstr()
+  end
+  if vim.fn.getchar(1) == 0 then
+    return nil
+  end
+  local code = vim.fn.getchar(0)
+  if code == 0 then
+    return nil
+  end
+  return type(code) == "number" and vim.fn.nr2char(code) or code
+end
+
+local function relative_jump(dir)
+  local n = read_relative_count(getchar_reader)
+  if n and n > 0 then
+    vim.cmd("normal! " .. n .. (dir == "up" and "k" or "j"))
+  end
+end
+
+map("n", "lu", function()
+  relative_jump("up")
+end, { desc = "Jump <count> relative lines up" })
+map("n", "ld", function()
+  relative_jump("down")
+end, { desc = "Jump <count> relative lines down" })

--- a/macbook/.config/nvim/lua/config/keymaps.lua
+++ b/macbook/.config/nvim/lua/config/keymaps.lua
@@ -36,3 +36,67 @@ map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })
 -- SPC q — quit
 map("n", "<leader>qq", "<cmd>qa<CR>", { desc = "Quit Neovim" })
 map("n", "<leader>qQ", "<cmd>qa!<CR>", { desc = "Quit without saving" })
+
+-- Relative-line jump: type the count AFTER the prefix (relativenumber shows it).
+--   lu<count>  jump <count> lines up      (== <count>k)
+--   ld<count>  jump <count> lines down    (== <count>j)
+-- The count is read live: fast-typed digits (lu52) are drained from the input
+-- queue, so no terminator key is needed; a pause commits (lu5 then jump). Esc
+-- cancels; a non-digit is replayed so no keystroke is lost.
+--
+-- read_relative_count is pure (input comes only from `next_char`) so it can be
+-- unit-tested. next_char(true) blocks for the first key; next_char(false)
+-- returns the next already-queued char or nil.
+local function read_relative_count(next_char)
+  local first = next_char(true)
+  if first == nil or first == "\27" then -- nothing / Esc: cancel
+    return nil
+  end
+  if not first:match("^%d$") then
+    vim.api.nvim_feedkeys(first, "n", false) -- not a number: replay, abort
+    return nil
+  end
+  local digits = first
+  while true do
+    local c = next_char(false) -- only chars already queued (fast typing)
+    if c == nil then
+      break
+    elseif c:match("^%d$") then
+      digits = digits .. c
+    else
+      vim.api.nvim_feedkeys(c, "n", false) -- non-digit: replay, stop
+      break
+    end
+  end
+  return tonumber(digits)
+end
+
+-- Default reader: blocking getcharstr for the first key, non-blocking getchar
+-- for the rest of the queue.
+local function getchar_reader(blocking)
+  if blocking then
+    return vim.fn.getcharstr()
+  end
+  if vim.fn.getchar(1) == 0 then
+    return nil
+  end
+  local code = vim.fn.getchar(0)
+  if code == 0 then
+    return nil
+  end
+  return type(code) == "number" and vim.fn.nr2char(code) or code
+end
+
+local function relative_jump(dir)
+  local n = read_relative_count(getchar_reader)
+  if n and n > 0 then
+    vim.cmd("normal! " .. n .. (dir == "up" and "k" or "j"))
+  end
+end
+
+map("n", "lu", function()
+  relative_jump("up")
+end, { desc = "Jump <count> relative lines up" })
+map("n", "ld", function()
+  relative_jump("down")
+end, { desc = "Jump <count> relative lines down" })


### PR DESCRIPTION
## What

Jump by a relative line count typed AFTER a mnemonic prefix (relativenumber shows the count in the gutter).

- `lu<count>` — jump `<count>` lines up (== `<count>k`)
- `ld<count>` — jump `<count>` lines down (== `<count>j`)

## Why

Vim counts go before the motion (`5k`). This lets the count come after a mnemonic prefix (l = line, u/d = up/down), matching how the gutter reads left-to-right.

## How

The count is read live via `getcharstr`/`getchar`: fast-typed digits (`lu52`) are drained from the input queue, so no terminator key is needed; a pause commits (`lu5` then jump). Esc cancels; a non-digit terminator is replayed so no keystroke is lost. The digit-accumulation is a pure function (`read_relative_count`) taking an injected reader.

## Verified

Unit-tested the pure reader headless: single digit, multi-digit (12, 305), Esc-cancel, empty, non-digit-abort, and digit+non-digit (count kept, terminator replayed) — all pass. Motion (`Nk`/`Nj`) and mapping registration confirmed.

macbook + linux both.

Note: `lu`/`ld` add a brief `timeoutlen` wait to a bare `l` (waiting to see if `u`/`d` follows) — inherent to a two-key mapping starting with `l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)