### PR TITLE
feat(nvim): switch git worktree SPC p w

### DIFF
--- a/linux/.config/nvim/lua/plugins/project.lua
+++ b/linux/.config/nvim/lua/plugins/project.lua
@@ -160,27 +160,35 @@ return {
         :find()
     end
 
-    -- Tabline: show each tab's "Project (worktree)" label (set at open time),
-    -- falling back to the tab-local cwd's dir name for tabs opened another way.
-    function _G.ProjectTabline()
+    -- Per-tab "Project (worktree)" label: the cached tab var, else the tab
+    -- cwd's dir name.
+    local function tab_label(tab, i)
+      local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
+      if not ok or label == nil or label == "" then
+        local cwd = vim.fn.getcwd(-1, i)
+        label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
+      end
+      return label
+    end
+
+    -- Neovim's real tabline is top-only, so to put the tabs at the BOTTOM of the
+    -- screen we render them in the global statusline (laststatus=3). Current file
+    -- + position sit on the right. Switch tabs with Alt+1..9.
+    function _G.ProjectTabsBar()
       local parts = {}
       local current = vim.api.nvim_get_current_tabpage()
       for i, tab in ipairs(vim.api.nvim_list_tabpages()) do
         local hl = (tab == current) and "%#TabLineSel#" or "%#TabLine#"
-        local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
-        if not ok or label == nil or label == "" then
-          local cwd = vim.fn.getcwd(-1, i)
-          label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
-        end
-        label = label:gsub("%%", "%%%%") -- escape for the statusline parser
-        parts[#parts + 1] = hl .. "%" .. i .. "T " .. label .. " "
+        local label = tab_label(tab, i):gsub("%%", "%%%%")
+        parts[#parts + 1] = string.format("%s %d:%s ", hl, i, label)
       end
-      parts[#parts + 1] = "%#TabLineFill#%T"
+      parts[#parts + 1] = "%#StatusLine#%= %f  %l:%c "
       return table.concat(parts)
     end
 
-    vim.o.tabline = "%!v:lua.ProjectTabline()"
-    vim.o.showtabline = 2
+    vim.o.showtabline = 0 -- hide the top tabline
+    vim.o.laststatus = 3 -- single global statusline, at the bottom
+    vim.o.statusline = "%!v:lua.ProjectTabsBar()"
 
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
     vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })

--- a/linux/.config/nvim/lua/plugins/project.lua
+++ b/linux/.config/nvim/lua/plugins/project.lua
@@ -160,35 +160,27 @@ return {
         :find()
     end
 
-    -- Per-tab "Project (worktree)" label: the cached tab var, else the tab
-    -- cwd's dir name.
-    local function tab_label(tab, i)
-      local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
-      if not ok or label == nil or label == "" then
-        local cwd = vim.fn.getcwd(-1, i)
-        label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
-      end
-      return label
-    end
-
-    -- Neovim's real tabline is top-only, so to put the tabs at the BOTTOM of the
-    -- screen we render them in the global statusline (laststatus=3). Current file
-    -- + position sit on the right. Switch tabs with Alt+1..9.
-    function _G.ProjectTabsBar()
+    -- Tabline: show each tab's "Project (worktree)" label (set at open time),
+    -- falling back to the tab-local cwd's dir name for tabs opened another way.
+    function _G.ProjectTabline()
       local parts = {}
       local current = vim.api.nvim_get_current_tabpage()
       for i, tab in ipairs(vim.api.nvim_list_tabpages()) do
         local hl = (tab == current) and "%#TabLineSel#" or "%#TabLine#"
-        local label = tab_label(tab, i):gsub("%%", "%%%%")
-        parts[#parts + 1] = string.format("%s %d:%s ", hl, i, label)
+        local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
+        if not ok or label == nil or label == "" then
+          local cwd = vim.fn.getcwd(-1, i)
+          label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
+        end
+        label = label:gsub("%%", "%%%%") -- escape for the statusline parser
+        parts[#parts + 1] = hl .. "%" .. i .. "T " .. label .. " "
       end
-      parts[#parts + 1] = "%#StatusLine#%= %f  %l:%c "
+      parts[#parts + 1] = "%#TabLineFill#%T"
       return table.concat(parts)
     end
 
-    vim.o.showtabline = 0 -- hide the top tabline
-    vim.o.laststatus = 3 -- single global statusline, at the bottom
-    vim.o.statusline = "%!v:lua.ProjectTabsBar()"
+    vim.o.tabline = "%!v:lua.ProjectTabline()"
+    vim.o.showtabline = 2
 
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
     vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })

--- a/linux/.config/nvim/lua/plugins/project.lua
+++ b/linux/.config/nvim/lua/plugins/project.lua
@@ -1,6 +1,7 @@
 -- project.nvim: track project roots; open each project as its own tab.
 -- One project per tabpage, each with a tab-local cwd (:tcd).
 --   SPC p o  pick a known project -> opens in a NEW tab (oil at its root)
+--   SPC p w  pick a git worktree of the current repo -> opens in a NEW tab
 --   SPC p q  close the current project (tabpage)
 --   Alt+1..9 switch to project (tab) N
 -- SPC p group is declared in which-key ("project").
@@ -70,7 +71,71 @@ return {
         :find()
     end
 
+    -- Parse `git worktree list --porcelain` into { path, branch } entries.
+    local function list_worktrees(cwd)
+      local out = vim.fn.systemlist({ "git", "-C", cwd, "worktree", "list", "--porcelain" })
+      if vim.v.shell_error ~= 0 then
+        return nil
+      end
+      local trees, cur = {}, nil
+      for _, line in ipairs(out) do
+        if line:match("^worktree ") then
+          cur = { path = line:sub(10), branch = "(detached)" }
+          table.insert(trees, cur)
+        elseif cur and line:match("^branch ") then
+          cur.branch = line:gsub("^branch refs/heads/", "")
+        elseif cur and line == "bare" then
+          cur.branch = "(bare)"
+        end
+      end
+      return trees
+    end
+
+    -- Telescope picker of the current repo's worktrees; the chosen one opens
+    -- in a new tab (same as opening a project).
+    local function pick_worktree()
+      local trees = list_worktrees(vim.fn.getcwd())
+      if not trees then
+        vim.notify("Not inside a git repository", vim.log.levels.WARN)
+        return
+      end
+      if vim.tbl_isempty(trees) then
+        vim.notify("No worktrees found", vim.log.levels.INFO)
+        return
+      end
+      local pickers = require("telescope.pickers")
+      local finders = require("telescope.finders")
+      local conf = require("telescope.config").values
+      local actions = require("telescope.actions")
+      local action_state = require("telescope.actions.state")
+      pickers
+        .new({}, {
+          prompt_title = "Git worktrees",
+          finder = finders.new_table({
+            results = trees,
+            entry_maker = function(t)
+              return {
+                value = t.path,
+                display = string.format("%-24s %s", t.branch, t.path),
+                ordinal = t.branch .. " " .. t.path,
+              }
+            end,
+          }),
+          sorter = conf.generic_sorter({}),
+          attach_mappings = function(bufnr)
+            actions.select_default:replace(function()
+              actions.close(bufnr)
+              local entry = action_state.get_selected_entry()
+              open_project_in_tab(entry and entry.value)
+            end)
+            return true
+          end,
+        })
+        :find()
+    end
+
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
+    vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })
     vim.keymap.set("n", "<leader>pq", "<cmd>tabclose<CR>", { desc = "Close project (tab)" })
     for i = 1, 9 do
       vim.keymap.set("n", ("<A-%d>"):format(i), ("%dgt"):format(i), { desc = "Go to project " .. i })

--- a/linux/.config/nvim/lua/plugins/project.lua
+++ b/linux/.config/nvim/lua/plugins/project.lua
@@ -27,13 +27,39 @@ return {
       },
     })
 
-    -- Open a folder as a project: new tab, tab-local cwd, oil at the root.
+    -- Build a tab label for a path: "Project" for the main worktree, or
+    -- "Project (worktree-dir)" for a linked worktree. The main worktree is the
+    -- first entry of `git worktree list`. Non-git paths fall back to the dir
+    -- name. Computed once at open time, then cached as a tab-local var.
+    local function tab_label_for(path)
+      local this = vim.fn.fnamemodify(path, ":t")
+      local wl = vim.fn.systemlist({ "git", "-C", path, "worktree", "list", "--porcelain" })
+      if vim.v.shell_error ~= 0 then
+        return this
+      end
+      local main
+      for _, l in ipairs(wl) do
+        local p = l:match("^worktree (.+)")
+        if p then
+          main = p
+          break
+        end
+      end
+      local project = main and vim.fn.fnamemodify(main, ":t") or this
+      if this == project then
+        return project
+      end
+      return string.format("%s (%s)", project, this)
+    end
+
+    -- Open a folder as a project: new tab, tab-local cwd, labelled, oil at root.
     local function open_project_in_tab(path)
       if not path or path == "" then
         return
       end
       vim.cmd("tabnew")
       vim.cmd("tcd " .. vim.fn.fnameescape(path))
+      vim.api.nvim_tabpage_set_var(0, "project_label", tab_label_for(path))
       require("oil").open(path)
     end
 
@@ -133,6 +159,28 @@ return {
         })
         :find()
     end
+
+    -- Tabline: show each tab's "Project (worktree)" label (set at open time),
+    -- falling back to the tab-local cwd's dir name for tabs opened another way.
+    function _G.ProjectTabline()
+      local parts = {}
+      local current = vim.api.nvim_get_current_tabpage()
+      for i, tab in ipairs(vim.api.nvim_list_tabpages()) do
+        local hl = (tab == current) and "%#TabLineSel#" or "%#TabLine#"
+        local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
+        if not ok or label == nil or label == "" then
+          local cwd = vim.fn.getcwd(-1, i)
+          label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
+        end
+        label = label:gsub("%%", "%%%%") -- escape for the statusline parser
+        parts[#parts + 1] = hl .. "%" .. i .. "T " .. label .. " "
+      end
+      parts[#parts + 1] = "%#TabLineFill#%T"
+      return table.concat(parts)
+    end
+
+    vim.o.tabline = "%!v:lua.ProjectTabline()"
+    vim.o.showtabline = 2
 
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
     vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })

--- a/macbook/.config/nvim/lua/plugins/project.lua
+++ b/macbook/.config/nvim/lua/plugins/project.lua
@@ -160,27 +160,35 @@ return {
         :find()
     end
 
-    -- Tabline: show each tab's "Project (worktree)" label (set at open time),
-    -- falling back to the tab-local cwd's dir name for tabs opened another way.
-    function _G.ProjectTabline()
+    -- Per-tab "Project (worktree)" label: the cached tab var, else the tab
+    -- cwd's dir name.
+    local function tab_label(tab, i)
+      local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
+      if not ok or label == nil or label == "" then
+        local cwd = vim.fn.getcwd(-1, i)
+        label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
+      end
+      return label
+    end
+
+    -- Neovim's real tabline is top-only, so to put the tabs at the BOTTOM of the
+    -- screen we render them in the global statusline (laststatus=3). Current file
+    -- + position sit on the right. Switch tabs with Alt+1..9.
+    function _G.ProjectTabsBar()
       local parts = {}
       local current = vim.api.nvim_get_current_tabpage()
       for i, tab in ipairs(vim.api.nvim_list_tabpages()) do
         local hl = (tab == current) and "%#TabLineSel#" or "%#TabLine#"
-        local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
-        if not ok or label == nil or label == "" then
-          local cwd = vim.fn.getcwd(-1, i)
-          label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
-        end
-        label = label:gsub("%%", "%%%%") -- escape for the statusline parser
-        parts[#parts + 1] = hl .. "%" .. i .. "T " .. label .. " "
+        local label = tab_label(tab, i):gsub("%%", "%%%%")
+        parts[#parts + 1] = string.format("%s %d:%s ", hl, i, label)
       end
-      parts[#parts + 1] = "%#TabLineFill#%T"
+      parts[#parts + 1] = "%#StatusLine#%= %f  %l:%c "
       return table.concat(parts)
     end
 
-    vim.o.tabline = "%!v:lua.ProjectTabline()"
-    vim.o.showtabline = 2
+    vim.o.showtabline = 0 -- hide the top tabline
+    vim.o.laststatus = 3 -- single global statusline, at the bottom
+    vim.o.statusline = "%!v:lua.ProjectTabsBar()"
 
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
     vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })

--- a/macbook/.config/nvim/lua/plugins/project.lua
+++ b/macbook/.config/nvim/lua/plugins/project.lua
@@ -160,35 +160,27 @@ return {
         :find()
     end
 
-    -- Per-tab "Project (worktree)" label: the cached tab var, else the tab
-    -- cwd's dir name.
-    local function tab_label(tab, i)
-      local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
-      if not ok or label == nil or label == "" then
-        local cwd = vim.fn.getcwd(-1, i)
-        label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
-      end
-      return label
-    end
-
-    -- Neovim's real tabline is top-only, so to put the tabs at the BOTTOM of the
-    -- screen we render them in the global statusline (laststatus=3). Current file
-    -- + position sit on the right. Switch tabs with Alt+1..9.
-    function _G.ProjectTabsBar()
+    -- Tabline: show each tab's "Project (worktree)" label (set at open time),
+    -- falling back to the tab-local cwd's dir name for tabs opened another way.
+    function _G.ProjectTabline()
       local parts = {}
       local current = vim.api.nvim_get_current_tabpage()
       for i, tab in ipairs(vim.api.nvim_list_tabpages()) do
         local hl = (tab == current) and "%#TabLineSel#" or "%#TabLine#"
-        local label = tab_label(tab, i):gsub("%%", "%%%%")
-        parts[#parts + 1] = string.format("%s %d:%s ", hl, i, label)
+        local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
+        if not ok or label == nil or label == "" then
+          local cwd = vim.fn.getcwd(-1, i)
+          label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
+        end
+        label = label:gsub("%%", "%%%%") -- escape for the statusline parser
+        parts[#parts + 1] = hl .. "%" .. i .. "T " .. label .. " "
       end
-      parts[#parts + 1] = "%#StatusLine#%= %f  %l:%c "
+      parts[#parts + 1] = "%#TabLineFill#%T"
       return table.concat(parts)
     end
 
-    vim.o.showtabline = 0 -- hide the top tabline
-    vim.o.laststatus = 3 -- single global statusline, at the bottom
-    vim.o.statusline = "%!v:lua.ProjectTabsBar()"
+    vim.o.tabline = "%!v:lua.ProjectTabline()"
+    vim.o.showtabline = 2
 
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
     vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })

--- a/macbook/.config/nvim/lua/plugins/project.lua
+++ b/macbook/.config/nvim/lua/plugins/project.lua
@@ -1,6 +1,7 @@
 -- project.nvim: track project roots; open each project as its own tab.
 -- One project per tabpage, each with a tab-local cwd (:tcd).
 --   SPC p o  pick a known project -> opens in a NEW tab (oil at its root)
+--   SPC p w  pick a git worktree of the current repo -> opens in a NEW tab
 --   SPC p q  close the current project (tabpage)
 --   Alt+1..9 switch to project (tab) N
 -- SPC p group is declared in which-key ("project").
@@ -70,7 +71,71 @@ return {
         :find()
     end
 
+    -- Parse `git worktree list --porcelain` into { path, branch } entries.
+    local function list_worktrees(cwd)
+      local out = vim.fn.systemlist({ "git", "-C", cwd, "worktree", "list", "--porcelain" })
+      if vim.v.shell_error ~= 0 then
+        return nil
+      end
+      local trees, cur = {}, nil
+      for _, line in ipairs(out) do
+        if line:match("^worktree ") then
+          cur = { path = line:sub(10), branch = "(detached)" }
+          table.insert(trees, cur)
+        elseif cur and line:match("^branch ") then
+          cur.branch = line:gsub("^branch refs/heads/", "")
+        elseif cur and line == "bare" then
+          cur.branch = "(bare)"
+        end
+      end
+      return trees
+    end
+
+    -- Telescope picker of the current repo's worktrees; the chosen one opens
+    -- in a new tab (same as opening a project).
+    local function pick_worktree()
+      local trees = list_worktrees(vim.fn.getcwd())
+      if not trees then
+        vim.notify("Not inside a git repository", vim.log.levels.WARN)
+        return
+      end
+      if vim.tbl_isempty(trees) then
+        vim.notify("No worktrees found", vim.log.levels.INFO)
+        return
+      end
+      local pickers = require("telescope.pickers")
+      local finders = require("telescope.finders")
+      local conf = require("telescope.config").values
+      local actions = require("telescope.actions")
+      local action_state = require("telescope.actions.state")
+      pickers
+        .new({}, {
+          prompt_title = "Git worktrees",
+          finder = finders.new_table({
+            results = trees,
+            entry_maker = function(t)
+              return {
+                value = t.path,
+                display = string.format("%-24s %s", t.branch, t.path),
+                ordinal = t.branch .. " " .. t.path,
+              }
+            end,
+          }),
+          sorter = conf.generic_sorter({}),
+          attach_mappings = function(bufnr)
+            actions.select_default:replace(function()
+              actions.close(bufnr)
+              local entry = action_state.get_selected_entry()
+              open_project_in_tab(entry and entry.value)
+            end)
+            return true
+          end,
+        })
+        :find()
+    end
+
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
+    vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })
     vim.keymap.set("n", "<leader>pq", "<cmd>tabclose<CR>", { desc = "Close project (tab)" })
     for i = 1, 9 do
       vim.keymap.set("n", ("<A-%d>"):format(i), ("%dgt"):format(i), { desc = "Go to project " .. i })

--- a/macbook/.config/nvim/lua/plugins/project.lua
+++ b/macbook/.config/nvim/lua/plugins/project.lua
@@ -27,13 +27,39 @@ return {
       },
     })
 
-    -- Open a folder as a project: new tab, tab-local cwd, oil at the root.
+    -- Build a tab label for a path: "Project" for the main worktree, or
+    -- "Project (worktree-dir)" for a linked worktree. The main worktree is the
+    -- first entry of `git worktree list`. Non-git paths fall back to the dir
+    -- name. Computed once at open time, then cached as a tab-local var.
+    local function tab_label_for(path)
+      local this = vim.fn.fnamemodify(path, ":t")
+      local wl = vim.fn.systemlist({ "git", "-C", path, "worktree", "list", "--porcelain" })
+      if vim.v.shell_error ~= 0 then
+        return this
+      end
+      local main
+      for _, l in ipairs(wl) do
+        local p = l:match("^worktree (.+)")
+        if p then
+          main = p
+          break
+        end
+      end
+      local project = main and vim.fn.fnamemodify(main, ":t") or this
+      if this == project then
+        return project
+      end
+      return string.format("%s (%s)", project, this)
+    end
+
+    -- Open a folder as a project: new tab, tab-local cwd, labelled, oil at root.
     local function open_project_in_tab(path)
       if not path or path == "" then
         return
       end
       vim.cmd("tabnew")
       vim.cmd("tcd " .. vim.fn.fnameescape(path))
+      vim.api.nvim_tabpage_set_var(0, "project_label", tab_label_for(path))
       require("oil").open(path)
     end
 
@@ -133,6 +159,28 @@ return {
         })
         :find()
     end
+
+    -- Tabline: show each tab's "Project (worktree)" label (set at open time),
+    -- falling back to the tab-local cwd's dir name for tabs opened another way.
+    function _G.ProjectTabline()
+      local parts = {}
+      local current = vim.api.nvim_get_current_tabpage()
+      for i, tab in ipairs(vim.api.nvim_list_tabpages()) do
+        local hl = (tab == current) and "%#TabLineSel#" or "%#TabLine#"
+        local ok, label = pcall(vim.api.nvim_tabpage_get_var, tab, "project_label")
+        if not ok or label == nil or label == "" then
+          local cwd = vim.fn.getcwd(-1, i)
+          label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
+        end
+        label = label:gsub("%%", "%%%%") -- escape for the statusline parser
+        parts[#parts + 1] = hl .. "%" .. i .. "T " .. label .. " "
+      end
+      parts[#parts + 1] = "%#TabLineFill#%T"
+      return table.concat(parts)
+    end
+
+    vim.o.tabline = "%!v:lua.ProjectTabline()"
+    vim.o.showtabline = 2
 
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
     vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })


### PR DESCRIPTION
## What

- `SPC p w` — pick a git worktree of the current repo, open it in a new tab.
- Tab labels: `Project` (main worktree) or `Project (worktree-dir)` for linked worktrees.

## How

- **Switch**: `git worktree list --porcelain` in the current tab's cwd, parsed into `{ path, branch }` (branch, or `(detached)`/`(bare)`). Telescope picker; the choice opens in a new tab via `open_project_in_tab` (tab-local `tcd` + oil at root). Not a repo → warning, no-op.
- **Labels**: computed once at open time (main worktree = first `git worktree list` entry; `Project` if this dir is the main worktree, else `Project (dir)`), cached as a tab-local var. A custom top tabline renders each tab's label, falling back to the tab cwd's dir name. `showtabline=2`.

Switch-only; create/remove stay as terminal `git worktree add/remove`. Custom (no worktree plugin), consistent with `project.lua`.

(A bottom-tabs variant was tried and reverted — tabs stay on top.)

## Verified

- Parser: branch / detached / multiple worktrees parse correctly.
- Label: main → `ProjectX`, worktree → `ProjectX (wt-feature)`, non-git → dir name.
- Top tabline renders labels with `TabLineSel`/`TabLine` highlights + click regions.
- Keymap binds; syntax clean.

macbook + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)