### PR TITLE
fix(nvim): telescope preview no treesitter

### DIFF
--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -37,6 +37,10 @@ return {
   opts = {
     defaults = {
       path_display = path_display,
+      -- Preview highlighting via built-in syntax, not treesitter: telescope 0.1.x
+      -- calls the removed nvim-treesitter master API (ft_to_lang), which errors
+      -- against the main branch (required for Neovim 0.12). Regex preview works.
+      preview = { treesitter = false },
     },
     pickers = {
       -- rg --files respects .gitignore; avoids `find` fallback that lists ignored files

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -37,6 +37,10 @@ return {
   opts = {
     defaults = {
       path_display = path_display,
+      -- Preview highlighting via built-in syntax, not treesitter: telescope 0.1.x
+      -- calls the removed nvim-treesitter master API (ft_to_lang), which errors
+      -- against the main branch (required for Neovim 0.12). Regex preview works.
+      preview = { treesitter = false },
     },
     pickers = {
       -- rg --files respects .gitignore; avoids `find` fallback that lists ignored files


### PR DESCRIPTION
## What

Fix `previewers/utils.lua:135: attempt to call field 'ft_to_lang' (a nil value)` when opening telescope (SPC SPC).

## Root cause

telescope 0.1.x's preview highlighter uses the **nvim-treesitter master** API (`parsers.ft_to_lang`, `configs.is_enabled`, `configs.get_module`). Those were removed on the **main** branch — which we switched to for Neovim 0.12 (#21). So telescope's treesitter preview path errors.

## Fix

`defaults.preview.treesitter = false` — telescope then highlights previews with built-in syntax (regex) and never calls the removed API. Keeps telescope pinned.

## Verified

Drove telescope's real `previewers.utils.highlighter` on a lua buffer:
- `treesitter = true` → errors with `ft_to_lang` (reproduces the report)
- `treesitter = false` → clean, no error

Resolved config confirms `preview.treesitter = false`. macbook + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)