### PR TITLE
feat(nvim): SPC t T terminal in its own tab

### DIFF
--- a/linux/.config/nvim/lua/config/keymaps.lua
+++ b/linux/.config/nvim/lua/config/keymaps.lua
@@ -8,6 +8,12 @@ map("n", "<Esc>", "<cmd>nohlsearch<CR>")
 -- Terminal: double-Esc leaves insert mode
 map("t", "<Esc><Esc>", "<C-\\><C-n>", { desc = "Exit terminal insert mode" })
 
+-- Terminal: Alt+1..9 jump to tab N without leaving terminal mode first, so a
+-- terminal tab navigates like a project tab (normal-mode Alt+N is in project.lua).
+for i = 1, 9 do
+  map("t", ("<A-%d>"):format(i), ([[<C-\><C-n>%dgt]]):format(i), { desc = "Go to tab " .. i })
+end
+
 -- Move selected lines
 map("v", "J", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
 map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })

--- a/linux/.config/nvim/lua/plugins/toggleterm.lua
+++ b/linux/.config/nvim/lua/plugins/toggleterm.lua
@@ -3,8 +3,10 @@
 --   SPC t s  bottom split, full width, pushes buffers up (30% height)
 --   SPC t v  right split, 30% width, pushes buffers left
 --   SPC t c  float 90%, runs claude code; toggle hides it (process stays alive)
+--   SPC t T  terminal in its own tab ("Terminal"); closing the tab ends it
 --   SPC t q  kill the active terminal, ending its process
 -- Distinct <count> per mapping = three independent, persistent terminals.
+-- SPC t T tabs join the project tab row; jump to them with Alt+1..9.
 
 -- Dedicated Claude Code terminal. Built once, reused so toggle hides/shows the
 -- same job instead of spawning a new one. close_on_exit=false keeps the buffer
@@ -43,6 +45,18 @@ local function kill_terminal()
   end
 end
 
+-- Open a terminal in its own tab, like a project tab. The tabline shows
+-- "Terminal" (reusing project.lua's tab-local `project_label`), and
+-- bufhidden=wipe ends the job the instant the tab is closed. Alt+1..9 jump
+-- between tabs (terminal-mode variants live in config/keymaps.lua).
+local function terminal_in_tab()
+  vim.cmd("tabnew")
+  vim.api.nvim_tabpage_set_var(0, "project_label", "Terminal")
+  vim.cmd("terminal")
+  vim.bo.bufhidden = "wipe"
+  vim.cmd("startinsert")
+end
+
 return {
   "akinsho/toggleterm.nvim",
   version = "*",
@@ -67,6 +81,7 @@ return {
     { "<leader>tt", "<cmd>1ToggleTerm direction=float<cr>", desc = "Terminal (float 80%)" },
     { "<leader>ts", "<cmd>2ToggleTerm direction=horizontal<cr>", desc = "Terminal (bottom split)" },
     { "<leader>tv", "<cmd>3ToggleTerm direction=vertical<cr>", desc = "Terminal (right split)" },
+    { "<leader>tT", terminal_in_tab, desc = "Terminal (new tab)" },
     { "<leader>tc", toggle_claude, desc = "Terminal (Claude Code, 90%)" },
     { "<leader>tq", kill_terminal, desc = "Kill active terminal" },
   },

--- a/macbook/.config/nvim/lua/config/keymaps.lua
+++ b/macbook/.config/nvim/lua/config/keymaps.lua
@@ -8,6 +8,12 @@ map("n", "<Esc>", "<cmd>nohlsearch<CR>")
 -- Terminal: double-Esc leaves insert mode
 map("t", "<Esc><Esc>", "<C-\\><C-n>", { desc = "Exit terminal insert mode" })
 
+-- Terminal: Alt+1..9 jump to tab N without leaving terminal mode first, so a
+-- terminal tab navigates like a project tab (normal-mode Alt+N is in project.lua).
+for i = 1, 9 do
+  map("t", ("<A-%d>"):format(i), ([[<C-\><C-n>%dgt]]):format(i), { desc = "Go to tab " .. i })
+end
+
 -- Move selected lines
 map("v", "J", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
 map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })

--- a/macbook/.config/nvim/lua/plugins/toggleterm.lua
+++ b/macbook/.config/nvim/lua/plugins/toggleterm.lua
@@ -3,8 +3,10 @@
 --   SPC t s  bottom split, full width, pushes buffers up (30% height)
 --   SPC t v  right split, 30% width, pushes buffers left
 --   SPC t c  float 90%, runs claude code; toggle hides it (process stays alive)
+--   SPC t T  terminal in its own tab ("Terminal"); closing the tab ends it
 --   SPC t q  kill the active terminal, ending its process
 -- Distinct <count> per mapping = three independent, persistent terminals.
+-- SPC t T tabs join the project tab row; jump to them with Alt+1..9.
 
 -- Dedicated Claude Code terminal. Built once, reused so toggle hides/shows the
 -- same job instead of spawning a new one. close_on_exit=false keeps the buffer
@@ -43,6 +45,18 @@ local function kill_terminal()
   end
 end
 
+-- Open a terminal in its own tab, like a project tab. The tabline shows
+-- "Terminal" (reusing project.lua's tab-local `project_label`), and
+-- bufhidden=wipe ends the job the instant the tab is closed. Alt+1..9 jump
+-- between tabs (terminal-mode variants live in config/keymaps.lua).
+local function terminal_in_tab()
+  vim.cmd("tabnew")
+  vim.api.nvim_tabpage_set_var(0, "project_label", "Terminal")
+  vim.cmd("terminal")
+  vim.bo.bufhidden = "wipe"
+  vim.cmd("startinsert")
+end
+
 return {
   "akinsho/toggleterm.nvim",
   version = "*",
@@ -67,6 +81,7 @@ return {
     { "<leader>tt", "<cmd>1ToggleTerm direction=float<cr>", desc = "Terminal (float 80%)" },
     { "<leader>ts", "<cmd>2ToggleTerm direction=horizontal<cr>", desc = "Terminal (bottom split)" },
     { "<leader>tv", "<cmd>3ToggleTerm direction=vertical<cr>", desc = "Terminal (right split)" },
+    { "<leader>tT", terminal_in_tab, desc = "Terminal (new tab)" },
     { "<leader>tc", toggle_claude, desc = "Terminal (Claude Code, 90%)" },
     { "<leader>tq", kill_terminal, desc = "Kill active terminal" },
   },


### PR DESCRIPTION
## what

new command **SPC t T** open a terminal in its own tab, like project open in tab.

- tab label = **"Terminal"** in the tab row (reuse project.lua `project_label` var)
- **Alt+1..9** jump to tab, now also from **terminal mode** (no need exit insert first). match project tab move.
- close the tab **kill the terminal job** (`bufhidden = "wipe"`)

## files

- `toggleterm.lua` (mac + linux) — `terminal_in_tab()` fn + `SPC t T` key
- `keymaps.lua` (mac + linux) — terminal-mode `Alt+1..9` -> `<C-\><C-n>Ngt`

## note

normal-mode Alt+1..9 already exist (project.lua). this add terminal-mode twin so terminal tab move same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)