### PR TITLE
feat(zsh): jump plugin + j <mark> helper

### DIFF
--- a/linux/.zshrc
+++ b/linux/.zshrc
@@ -77,7 +77,7 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=()
+plugins=(jump)
 
 source $ZSH/oh-my-zsh.sh
 
@@ -109,6 +109,12 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# j <mark> — jump to a dir bookmarked with the jump plugin.
+# Save a mark: `mark <name>` in the dir; list: `marks`; remove: `unmark <name>`.
+j() {
+  jump "$1"
+}
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh

--- a/macbook/.zshrc
+++ b/macbook/.zshrc
@@ -77,7 +77,7 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=()
+plugins=(jump)
 
 source $ZSH/oh-my-zsh.sh
 
@@ -109,6 +109,12 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# j <mark> — jump to a dir bookmarked with the jump plugin.
+# Save a mark: `mark <name>` in the dir; list: `marks`; remove: `unmark <name>`.
+j() {
+  jump "$1"
+}
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh


### PR DESCRIPTION
## what

bring back v1 jump. now zsh can bookmark dir and hop to it.

- turn on oh-my-zsh **jump** plugin (`plugins=(jump)`) -> give `mark` / `jump` / `unmark` / `marks`
- add **j()** function like v1: `j <mark>` jump to saved dir

## use

- `mark work` -> save current dir as "work"
- `j work` -> jump there
- `marks` -> list all, `unmark work` -> remove

jump plugin ship with oh-my-zsh, no extra install. mac + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)