### PR TITLE
feat(zsh): add neovim tarball dir to PATH

### DIFF
--- a/linux/.zshrc
+++ b/linux/.zshrc
@@ -114,6 +114,9 @@ source $ZSH/oh-my-zsh.sh
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 export PATH="$HOME/.local/bin:$PATH"
 
+# Neovim (official tarball install) — add to PATH only where it exists.
+[[ -d /opt/nvim-linux-x86_64/bin ]] && export PATH="/opt/nvim-linux-x86_64/bin:$PATH"
+
 #THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
 export SDKMAN_DIR="$HOME/.sdkman"
 [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"

--- a/macbook/.zshrc
+++ b/macbook/.zshrc
@@ -114,6 +114,9 @@ source $ZSH/oh-my-zsh.sh
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 export PATH="$HOME/.local/bin:$PATH"
 
+# Neovim (official tarball install) — add to PATH only where it exists.
+[[ -d /opt/nvim-linux-x86_64/bin ]] && export PATH="/opt/nvim-linux-x86_64/bin:$PATH"
+
 #THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
 export SDKMAN_DIR="$HOME/.sdkman"
 [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"


### PR DESCRIPTION
## what

put official neovim tarball bin on PATH so `nvim` run from anywhere.

`[[ -d /opt/nvim-linux-x86_64/bin ]] && export PATH="/opt/nvim-linux-x86_64/bin:$PATH"`

## careful

- **guard** with dir check: mac has no such dir (nvim from brew already on PATH), so line do nothing there. safe on both.

mac + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)