### PR TITLE
feat(nvim): SPC c a run LSP code action

### DIFF
--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -60,6 +60,7 @@ return {
           end
           m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
           m("<leader>cD", vim.lsp.buf.references, "Find usages")
+          m("<leader>ca", vim.lsp.buf.code_action, "Code action")
           m("<leader>cf", function()
             vim.lsp.buf.format({ async = true })
           end, "Format buffer")

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -60,6 +60,7 @@ return {
           end
           m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
           m("<leader>cD", vim.lsp.buf.references, "Find usages")
+          m("<leader>ca", vim.lsp.buf.code_action, "Code action")
           m("<leader>cf", function()
             vim.lsp.buf.format({ async = true })
           end, "Format buffer")


### PR DESCRIPTION
## what

**SPC c a** now run LSP code action (`vim.lsp.buf.code_action`) on the buffer.

join the code group next to `cd` (definition), `cD` (usages), `cf` (format). bind per-buffer on LspAttach like the rest.

mac + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)