### PR TITLE
feat(nvim): jdtls via nvim-jdtls (fix code actions)

### DIFF
--- a/linux/.config/nvim/lua/plugins/jdtls.lua
+++ b/linux/.config/nvim/lua/plugins/jdtls.lua
@@ -1,0 +1,89 @@
+-- Java LSP via nvim-jdtls. The generic mason-lspconfig auto-enable path shares
+-- one jdtls -data workspace across every project and omits jdtls's
+-- extendedClientCapabilities, which leaves jdtls degraded: diagnostics work but
+-- code actions do not. nvim-jdtls gives each project its own workspace and sets
+-- those capabilities, unlocking add-import / organize-imports / generate /
+-- extract, etc. mason installs the jdtls binary (ensure_installed in lsp.lua);
+-- this spec only starts it. jdtls stays excluded from auto-enable in lsp.lua.
+return {
+  "mfussenegger/nvim-jdtls",
+  ft = "java",
+  dependencies = { "williamboman/mason.nvim" },
+  config = function()
+    -- jdtls's own JVM needs Java 21+. Prefer $JDTLS_JAVA_HOME, else the newest
+    -- SDKMAN java >= 21. Nil = let the mason launcher use JAVA_HOME / PATH.
+    local function jdtls_java_home()
+      if vim.env.JDTLS_JAVA_HOME then
+        return vim.env.JDTLS_JAVA_HOME
+      end
+      local dirs = vim.fn.glob(vim.fn.expand("~/.sdkman/candidates/java") .. "/*", true, true)
+      local best, best_major
+      for _, dir in ipairs(dirs) do
+        local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("^(%d+)"))
+        if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
+          if not best_major or major > best_major then
+            best, best_major = dir, major
+          end
+        end
+      end
+      return best
+    end
+
+    local jdtls_bin = vim.fn.stdpath("data") .. "/mason/bin/jdtls"
+
+    local function start()
+      local jdtls = require("jdtls")
+      local root = vim.fs.root(0, {
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        "settings.gradle",
+        "settings.gradle.kts",
+        "mvnw",
+        "gradlew",
+        ".git",
+      })
+      if not root then
+        return -- loose file, not in a project: skip rather than spawn a stray workspace
+      end
+
+      -- One -data workspace per project root (full path sanitised to a dir name),
+      -- so projects never share/corrupt each other's jdtls index.
+      local key = vim.fn.fnamemodify(root, ":p"):gsub("[/\\:]+", "-")
+      local workspace = vim.fn.stdpath("cache") .. "/jdtls/" .. key
+
+      -- extendedClientCapabilities is what unlocks jdtls's source actions.
+      local caps = jdtls.extendedClientCapabilities
+      caps.resolveAdditionalTextEditsSupport = true
+
+      local jhome = jdtls_java_home()
+      jdtls.start_or_attach({
+        cmd = { jdtls_bin, "-data", workspace },
+        cmd_env = jhome and { JAVA_HOME = jhome } or nil,
+        root_dir = root,
+        capabilities = require("blink.cmp").get_lsp_capabilities(),
+        init_options = { extendedClientCapabilities = caps },
+        on_attach = function(_, bufnr)
+          -- generic SPC c d/D/a/f come from lsp.lua's LspAttach; add the
+          -- jdtls-only organize-imports here.
+          vim.keymap.set("n", "<leader>co", jdtls.organize_imports, {
+            buffer = bufnr,
+            desc = "Organize imports",
+          })
+        end,
+      })
+    end
+
+    local group = vim.api.nvim_create_augroup("jdtls_start", { clear = true })
+    vim.api.nvim_create_autocmd("FileType", {
+      group = group,
+      pattern = "java",
+      callback = start,
+    })
+    -- The FileType event that lazy-loaded this plugin already fired for the
+    -- current buffer, so start it explicitly too.
+    if vim.bo.filetype == "java" then
+      start()
+    end
+  end,
+}

--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -1,6 +1,8 @@
 -- LSP: mason installs language servers, nvim-lspconfig provides their configs.
--- jdtls = Java. mason-lspconfig (v2) auto-enables installed servers.
--- Keymaps live under SPC c (code) and bind per-buffer when an LSP attaches.
+-- Java (jdtls) is driven by nvim-jdtls (see jdtls.lua) for a per-project
+-- workspace and the full code-action set, so it is excluded from
+-- mason-lspconfig's auto-enable here to avoid a double start. Any other server
+-- auto-enables. SPC c keymaps bind per-buffer on LspAttach for every LSP.
 return {
   {
     "williamboman/mason.nvim",
@@ -15,7 +17,8 @@ return {
       "neovim/nvim-lspconfig",
     },
     opts = {
-      ensure_installed = { "jdtls" },
+      ensure_installed = { "jdtls" }, -- still install the binary; nvim-jdtls runs it
+      automatic_enable = { exclude = { "jdtls" } }, -- jdtls is started by nvim-jdtls
     },
     config = function(_, opts)
       require("mason-lspconfig").setup(opts)
@@ -26,31 +29,6 @@ return {
       vim.lsp.config("*", {
         capabilities = require("blink.cmp").get_lsp_capabilities(),
       })
-
-      -- jdtls's own JVM needs Java 21+. Projects may target older Java; only
-      -- the server runtime is pinned here. Prefer $JDTLS_JAVA_HOME, else the
-      -- newest SDKMAN java >= 21. Nil = fall back to JAVA_HOME/PATH.
-      local function jdtls_java_home()
-        if vim.env.JDTLS_JAVA_HOME then
-          return vim.env.JDTLS_JAVA_HOME
-        end
-        local dirs = vim.fn.glob(vim.fn.expand("~/.sdkman/candidates/java") .. "/*", true, true)
-        local best, best_major
-        for _, dir in ipairs(dirs) do
-          local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("^(%d+)"))
-          if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
-            if not best_major or major > best_major then
-              best, best_major = dir, major
-            end
-          end
-        end
-        return best
-      end
-
-      local jhome = jdtls_java_home()
-      if jhome then
-        vim.lsp.config("jdtls", { cmd_env = { JAVA_HOME = jhome } })
-      end
 
       vim.api.nvim_create_autocmd("LspAttach", {
         desc = "LSP buffer-local keymaps",

--- a/macbook/.config/nvim/lua/plugins/jdtls.lua
+++ b/macbook/.config/nvim/lua/plugins/jdtls.lua
@@ -1,0 +1,89 @@
+-- Java LSP via nvim-jdtls. The generic mason-lspconfig auto-enable path shares
+-- one jdtls -data workspace across every project and omits jdtls's
+-- extendedClientCapabilities, which leaves jdtls degraded: diagnostics work but
+-- code actions do not. nvim-jdtls gives each project its own workspace and sets
+-- those capabilities, unlocking add-import / organize-imports / generate /
+-- extract, etc. mason installs the jdtls binary (ensure_installed in lsp.lua);
+-- this spec only starts it. jdtls stays excluded from auto-enable in lsp.lua.
+return {
+  "mfussenegger/nvim-jdtls",
+  ft = "java",
+  dependencies = { "williamboman/mason.nvim" },
+  config = function()
+    -- jdtls's own JVM needs Java 21+. Prefer $JDTLS_JAVA_HOME, else the newest
+    -- SDKMAN java >= 21. Nil = let the mason launcher use JAVA_HOME / PATH.
+    local function jdtls_java_home()
+      if vim.env.JDTLS_JAVA_HOME then
+        return vim.env.JDTLS_JAVA_HOME
+      end
+      local dirs = vim.fn.glob(vim.fn.expand("~/.sdkman/candidates/java") .. "/*", true, true)
+      local best, best_major
+      for _, dir in ipairs(dirs) do
+        local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("^(%d+)"))
+        if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
+          if not best_major or major > best_major then
+            best, best_major = dir, major
+          end
+        end
+      end
+      return best
+    end
+
+    local jdtls_bin = vim.fn.stdpath("data") .. "/mason/bin/jdtls"
+
+    local function start()
+      local jdtls = require("jdtls")
+      local root = vim.fs.root(0, {
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        "settings.gradle",
+        "settings.gradle.kts",
+        "mvnw",
+        "gradlew",
+        ".git",
+      })
+      if not root then
+        return -- loose file, not in a project: skip rather than spawn a stray workspace
+      end
+
+      -- One -data workspace per project root (full path sanitised to a dir name),
+      -- so projects never share/corrupt each other's jdtls index.
+      local key = vim.fn.fnamemodify(root, ":p"):gsub("[/\\:]+", "-")
+      local workspace = vim.fn.stdpath("cache") .. "/jdtls/" .. key
+
+      -- extendedClientCapabilities is what unlocks jdtls's source actions.
+      local caps = jdtls.extendedClientCapabilities
+      caps.resolveAdditionalTextEditsSupport = true
+
+      local jhome = jdtls_java_home()
+      jdtls.start_or_attach({
+        cmd = { jdtls_bin, "-data", workspace },
+        cmd_env = jhome and { JAVA_HOME = jhome } or nil,
+        root_dir = root,
+        capabilities = require("blink.cmp").get_lsp_capabilities(),
+        init_options = { extendedClientCapabilities = caps },
+        on_attach = function(_, bufnr)
+          -- generic SPC c d/D/a/f come from lsp.lua's LspAttach; add the
+          -- jdtls-only organize-imports here.
+          vim.keymap.set("n", "<leader>co", jdtls.organize_imports, {
+            buffer = bufnr,
+            desc = "Organize imports",
+          })
+        end,
+      })
+    end
+
+    local group = vim.api.nvim_create_augroup("jdtls_start", { clear = true })
+    vim.api.nvim_create_autocmd("FileType", {
+      group = group,
+      pattern = "java",
+      callback = start,
+    })
+    -- The FileType event that lazy-loaded this plugin already fired for the
+    -- current buffer, so start it explicitly too.
+    if vim.bo.filetype == "java" then
+      start()
+    end
+  end,
+}

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -1,6 +1,8 @@
 -- LSP: mason installs language servers, nvim-lspconfig provides their configs.
--- jdtls = Java. mason-lspconfig (v2) auto-enables installed servers.
--- Keymaps live under SPC c (code) and bind per-buffer when an LSP attaches.
+-- Java (jdtls) is driven by nvim-jdtls (see jdtls.lua) for a per-project
+-- workspace and the full code-action set, so it is excluded from
+-- mason-lspconfig's auto-enable here to avoid a double start. Any other server
+-- auto-enables. SPC c keymaps bind per-buffer on LspAttach for every LSP.
 return {
   {
     "williamboman/mason.nvim",
@@ -15,7 +17,8 @@ return {
       "neovim/nvim-lspconfig",
     },
     opts = {
-      ensure_installed = { "jdtls" },
+      ensure_installed = { "jdtls" }, -- still install the binary; nvim-jdtls runs it
+      automatic_enable = { exclude = { "jdtls" } }, -- jdtls is started by nvim-jdtls
     },
     config = function(_, opts)
       require("mason-lspconfig").setup(opts)
@@ -26,31 +29,6 @@ return {
       vim.lsp.config("*", {
         capabilities = require("blink.cmp").get_lsp_capabilities(),
       })
-
-      -- jdtls's own JVM needs Java 21+. Projects may target older Java; only
-      -- the server runtime is pinned here. Prefer $JDTLS_JAVA_HOME, else the
-      -- newest SDKMAN java >= 21. Nil = fall back to JAVA_HOME/PATH.
-      local function jdtls_java_home()
-        if vim.env.JDTLS_JAVA_HOME then
-          return vim.env.JDTLS_JAVA_HOME
-        end
-        local dirs = vim.fn.glob(vim.fn.expand("~/.sdkman/candidates/java") .. "/*", true, true)
-        local best, best_major
-        for _, dir in ipairs(dirs) do
-          local major = tonumber(vim.fn.fnamemodify(dir, ":t"):match("^(%d+)"))
-          if major and major >= 21 and vim.fn.isdirectory(dir) == 1 then
-            if not best_major or major > best_major then
-              best, best_major = dir, major
-            end
-          end
-        end
-        return best
-      end
-
-      local jhome = jdtls_java_home()
-      if jhome then
-        vim.lsp.config("jdtls", { cmd_env = { JAVA_HOME = jhome } })
-      end
 
       vim.api.nvim_create_autocmd("LspAttach", {
         desc = "LSP buffer-local keymaps",


### PR DESCRIPTION
## problem

`SPC c a` show "No code actions available" even for easy fix (add import), but jdtls attach fine and give diagnostics (red line).

cause: generic **mason-lspconfig auto-enable** run jdtls with **one shared -data workspace** and **no extendedClientCapabilities**. jdtls degrade: diagnostic yes, code action no.

## fix

drive jdtls with dedicated **nvim-jdtls**:
- own **-data workspace per project** (root by pom/gradle/mvnw/git)
- set **extendedClientCapabilities** -> unlock add-import, organize-import, generate, extract
- java 21+ runtime (prefer JDTLS_JAVA_HOME / sdkman), blink completion caps
- new key **SPC c o** organize imports
- generic **SPC c d/D/a/f** stay from lsp.lua LspAttach (fire for jdtls too)

jdtls now **exclude from mason auto-enable** (no double start), still install via `ensure_installed`.

## files

- `jdtls.lua` (new, mac + linux) — start jdtls on FileType java
- `lsp.lua` (mac + linux) — exclude jdtls from auto-enable, drop old jdtls-specific block

## test after merge

1. restart nvim (lazy install nvim-jdtls). open the quarkus project from root.
2. wait jdtls build finish (`:messages`).
3. `List<String> x;` no import -> cursor on List -> **SPC c a** should offer "Import 'List' (java.util)".
4. **SPC c o** organize imports.

note: could not run nvim here (author on windows box), so please test and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)