### PR TITLE
feat(nvim): editing keys + telescope find usages

### DIFF
--- a/linux/.config/nvim/lua/config/keymaps.lua
+++ b/linux/.config/nvim/lua/config/keymaps.lua
@@ -14,9 +14,15 @@ for i = 1, 9 do
   map("t", ("<A-%d>"):format(i), ([[<C-\><C-n>%dgt]]):format(i), { desc = "Go to tab " .. i })
 end
 
--- Move selected lines
+-- Move selected lines (J/K, plus Alt+Down/Up)
 map("v", "J", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
 map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
+map("v", "<A-Down>", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
+map("v", "<A-Up>", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
+
+-- Toggle comment on the visual selection with Ctrl+/ (terminals may send C-_)
+map("x", "<C-/>", "gc", { remap = true, desc = "Toggle comment" })
+map("x", "<C-_>", "gc", { remap = true, desc = "Toggle comment" })
 
 -- SPC w — window
 map("n", "<leader>ws", "<C-w>s", { desc = "Split window below" })
@@ -38,6 +44,9 @@ map("n", "<leader>bb", "<cmd>e #<CR>", { desc = "Switch to other buffer" })
 -- SPC f — file
 map("n", "<leader>fs", "<cmd>w<CR>", { desc = "Save file" })
 map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })
+
+-- SPC p — project (group also populated in plugins/project.lua)
+map("n", "<leader>ps", "<cmd>wa<CR>", { desc = "Save all project files" })
 
 -- SPC q — quit
 map("n", "<leader>qq", "<cmd>qa<CR>", { desc = "Quit Neovim" })

--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -59,7 +59,7 @@ return {
             vim.keymap.set("n", lhs, rhs, { buffer = ev.buf, desc = desc })
           end
           m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
-          m("<leader>cD", vim.lsp.buf.references, "Find usages")
+          m("<leader>cD", "<cmd>Telescope lsp_references<CR>", "Find usages")
           m("<leader>ca", vim.lsp.buf.code_action, "Code action")
           m("<leader>cf", function()
             vim.lsp.buf.format({ async = true })

--- a/macbook/.config/nvim/lua/config/keymaps.lua
+++ b/macbook/.config/nvim/lua/config/keymaps.lua
@@ -14,9 +14,15 @@ for i = 1, 9 do
   map("t", ("<A-%d>"):format(i), ([[<C-\><C-n>%dgt]]):format(i), { desc = "Go to tab " .. i })
 end
 
--- Move selected lines
+-- Move selected lines (J/K, plus Alt+Down/Up)
 map("v", "J", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
 map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
+map("v", "<A-Down>", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
+map("v", "<A-Up>", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
+
+-- Toggle comment on the visual selection with Ctrl+/ (terminals may send C-_)
+map("x", "<C-/>", "gc", { remap = true, desc = "Toggle comment" })
+map("x", "<C-_>", "gc", { remap = true, desc = "Toggle comment" })
 
 -- SPC w — window
 map("n", "<leader>ws", "<C-w>s", { desc = "Split window below" })
@@ -38,6 +44,9 @@ map("n", "<leader>bb", "<cmd>e #<CR>", { desc = "Switch to other buffer" })
 -- SPC f — file
 map("n", "<leader>fs", "<cmd>w<CR>", { desc = "Save file" })
 map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })
+
+-- SPC p — project (group also populated in plugins/project.lua)
+map("n", "<leader>ps", "<cmd>wa<CR>", { desc = "Save all project files" })
 
 -- SPC q — quit
 map("n", "<leader>qq", "<cmd>qa<CR>", { desc = "Quit Neovim" })

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -59,7 +59,7 @@ return {
             vim.keymap.set("n", lhs, rhs, { buffer = ev.buf, desc = desc })
           end
           m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
-          m("<leader>cD", vim.lsp.buf.references, "Find usages")
+          m("<leader>cD", "<cmd>Telescope lsp_references<CR>", "Find usages")
           m("<leader>ca", vim.lsp.buf.code_action, "Code action")
           m("<leader>cf", function()
             vim.lsp.buf.format({ async = true })


### PR DESCRIPTION
## what

- **SPC p s** save all project files (`:wa`)
- visual **Alt+Up / Alt+Down** move selected line up/down (twin of existing J/K)
- visual **Ctrl+/** toggle comment on selection (built-in `gc`; map both `<C-/>` and `<C-_>` since terminals send C-_ for ctrl+slash)
- **SPC c D** find usages now open in **telescope** (`Telescope lsp_references`) instead of the quickfix list

mac + linux both.

## note

`lsp.lua` change here also touch the `SPC c D` line. open PR #32 (nvim-jdtls) touch `lsp.lua` too but different region, so should merge clean. if conflict, ping me and i rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)