### PR TITLE
feat(nvim): spotless format + alt-arrow line move

### DIFF
--- a/linux/.config/nvim/lua/config/keymaps.lua
+++ b/linux/.config/nvim/lua/config/keymaps.lua
@@ -20,6 +20,12 @@ map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
 map("v", "<A-Down>", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
 map("v", "<A-Up>", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
 
+-- Move the current line with Alt+Up/Down in insert (edit) and normal mode.
+map("i", "<A-Down>", "<Esc>:m .+1<CR>==gi", { desc = "Move line down" })
+map("i", "<A-Up>", "<Esc>:m .-2<CR>==gi", { desc = "Move line up" })
+map("n", "<A-Down>", ":m .+1<CR>==", { desc = "Move line down" })
+map("n", "<A-Up>", ":m .-2<CR>==", { desc = "Move line up" })
+
 -- Toggle comment on the visual selection with Ctrl+/ (terminals may send C-_)
 map("x", "<C-/>", "gc", { remap = true, desc = "Toggle comment" })
 map("x", "<C-_>", "gc", { remap = true, desc = "Toggle comment" })

--- a/linux/.config/nvim/lua/plugins/conform.lua
+++ b/linux/.config/nvim/lua/plugins/conform.lua
@@ -1,0 +1,36 @@
+-- Formatting via conform.nvim. Java is formatted by the project's own Spotless,
+-- so the result matches `gradlew spotlessCheck` exactly -- including its import
+-- order -- rather than jdtls's Eclipse formatter. Spotless's IDE hook reads the
+-- buffer on stdin and returns the formatted text on stdout. It runs only when a
+-- Gradle root is found; otherwise (and for every non-Java filetype) SPC c f
+-- falls back to the LSP formatter. SPC c f is bound in lsp.lua.
+return {
+  "stevearc/conform.nvim",
+  lazy = true,
+  opts = function()
+    local util = require("conform.util")
+    return {
+      formatters = {
+        spotless = {
+          command = "./gradlew",
+          args = {
+            "spotlessApply",
+            "-PspotlessIdeHook=$FILENAME",
+            "-PspotlessIdeHookUseStdIn",
+            "-PspotlessIdeHookUseStdOut",
+            "--quiet",
+          },
+          stdin = true,
+          -- ./gradlew must run from the Gradle root; require_cwd skips Spotless
+          -- (so SPC c f falls back to the LSP formatter) when the file is not
+          -- inside a Gradle project.
+          cwd = util.root_file({ "settings.gradle", "settings.gradle.kts", "gradlew" }),
+          require_cwd = true,
+        },
+      },
+      formatters_by_ft = {
+        java = { "spotless" },
+      },
+    }
+  end,
+}

--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -40,7 +40,8 @@ return {
           m("<leader>cD", "<cmd>Telescope lsp_references<CR>", "Find usages")
           m("<leader>ca", vim.lsp.buf.code_action, "Code action")
           m("<leader>cf", function()
-            vim.lsp.buf.format({ async = true })
+            -- Java -> Spotless (conform); other filetypes fall back to the LSP.
+            require("conform").format({ async = true, lsp_format = "fallback" })
           end, "Format buffer")
         end,
       })

--- a/macbook/.config/nvim/lua/config/keymaps.lua
+++ b/macbook/.config/nvim/lua/config/keymaps.lua
@@ -20,6 +20,12 @@ map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
 map("v", "<A-Down>", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
 map("v", "<A-Up>", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
 
+-- Move the current line with Alt+Up/Down in insert (edit) and normal mode.
+map("i", "<A-Down>", "<Esc>:m .+1<CR>==gi", { desc = "Move line down" })
+map("i", "<A-Up>", "<Esc>:m .-2<CR>==gi", { desc = "Move line up" })
+map("n", "<A-Down>", ":m .+1<CR>==", { desc = "Move line down" })
+map("n", "<A-Up>", ":m .-2<CR>==", { desc = "Move line up" })
+
 -- Toggle comment on the visual selection with Ctrl+/ (terminals may send C-_)
 map("x", "<C-/>", "gc", { remap = true, desc = "Toggle comment" })
 map("x", "<C-_>", "gc", { remap = true, desc = "Toggle comment" })

--- a/macbook/.config/nvim/lua/plugins/conform.lua
+++ b/macbook/.config/nvim/lua/plugins/conform.lua
@@ -1,0 +1,36 @@
+-- Formatting via conform.nvim. Java is formatted by the project's own Spotless,
+-- so the result matches `gradlew spotlessCheck` exactly -- including its import
+-- order -- rather than jdtls's Eclipse formatter. Spotless's IDE hook reads the
+-- buffer on stdin and returns the formatted text on stdout. It runs only when a
+-- Gradle root is found; otherwise (and for every non-Java filetype) SPC c f
+-- falls back to the LSP formatter. SPC c f is bound in lsp.lua.
+return {
+  "stevearc/conform.nvim",
+  lazy = true,
+  opts = function()
+    local util = require("conform.util")
+    return {
+      formatters = {
+        spotless = {
+          command = "./gradlew",
+          args = {
+            "spotlessApply",
+            "-PspotlessIdeHook=$FILENAME",
+            "-PspotlessIdeHookUseStdIn",
+            "-PspotlessIdeHookUseStdOut",
+            "--quiet",
+          },
+          stdin = true,
+          -- ./gradlew must run from the Gradle root; require_cwd skips Spotless
+          -- (so SPC c f falls back to the LSP formatter) when the file is not
+          -- inside a Gradle project.
+          cwd = util.root_file({ "settings.gradle", "settings.gradle.kts", "gradlew" }),
+          require_cwd = true,
+        },
+      },
+      formatters_by_ft = {
+        java = { "spotless" },
+      },
+    }
+  end,
+}

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -40,7 +40,8 @@ return {
           m("<leader>cD", "<cmd>Telescope lsp_references<CR>", "Find usages")
           m("<leader>ca", vim.lsp.buf.code_action, "Code action")
           m("<leader>cf", function()
-            vim.lsp.buf.format({ async = true })
+            -- Java -> Spotless (conform); other filetypes fall back to the LSP.
+            require("conform").format({ async = true, lsp_format = "fallback" })
           end, "Format buffer")
         end,
       })


### PR DESCRIPTION
## what

two thing (bundled per request):

### 1. SPC c f -> spotless format (java)
- add **conform.nvim**. java file format by project own **spotless** via gradle ide hook (stdin/stdout), so output match `gradlew spotlessCheck` exact, incl spotless import order.
- non-java / no gradle root -> fall back to LSP format.

### 2. alt+up/down move current line
- **insert (edit) mode** and **normal mode**: alt+up/down move the whole current line up/down (like vscode).
- visual mode keep moving the selection.

## files

- `conform.lua` (new, mac + linux)
- `lsp.lua` (mac + linux) — SPC c f call conform
- `keymaps.lua` (mac + linux) — alt+up/down line move in insert/normal

## note

- spotless need the gradle build working (the import issue still open).
- alt+up/down only reach nvim if **windows terminal** no eat them — the WT `alt+up`/`alt+down` unbind must be active (already in settings.json, need WT full restart).
- author on windows box, cannot run nvim here — please test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)