### PR TITLE
feat(nvim): add-project command + typescript lsp

### DIFF
--- a/linux/.config/nvim/lua/plugins/jdtls.lua
+++ b/linux/.config/nvim/lua/plugins/jdtls.lua
@@ -3,9 +3,26 @@
 -- extendedClientCapabilities, which leaves jdtls degraded: diagnostics work but
 -- code actions do not. nvim-jdtls gives each project its own workspace and sets
 -- those capabilities, unlocking add-import / organize-imports / generate /
--- extract, etc. mason installs the jdtls binary (ensure_installed in lsp.lua);
--- this spec only starts it. jdtls stays excluded from auto-enable in lsp.lua.
-return {
+-- extract, etc. This file owns all of Java's LSP config: it installs the jdtls
+-- binary via mason and keeps it out of auto-enable (nvim-jdtls starts it), then
+-- drives nvim-jdtls itself.
+
+-- Java owns its mason entry: install jdtls, but let nvim-jdtls start it. An opts
+-- function that initialises the lists then extends them in place -- lazy runs
+-- fragments in filename order and replaces list-valued table opts, so each
+-- contributor must defensively init before extending.
+local mason_jdtls = {
+  "williamboman/mason-lspconfig.nvim",
+  opts = function(_, opts)
+    opts.ensure_installed = opts.ensure_installed or {}
+    opts.automatic_enable = opts.automatic_enable or {}
+    opts.automatic_enable.exclude = opts.automatic_enable.exclude or {}
+    vim.list_extend(opts.ensure_installed, { "jdtls" })
+    vim.list_extend(opts.automatic_enable.exclude, { "jdtls" })
+  end,
+}
+
+local nvim_jdtls = {
   "mfussenegger/nvim-jdtls",
   ft = "java",
   dependencies = { "williamboman/mason.nvim" },
@@ -87,3 +104,5 @@ return {
     end
   end,
 }
+
+return { mason_jdtls, nvim_jdtls }

--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -1,8 +1,15 @@
--- LSP: mason installs language servers, nvim-lspconfig provides their configs.
--- Java (jdtls) is driven by nvim-jdtls (see jdtls.lua) for a per-project
--- workspace and the full code-action set, so it is excluded from
--- mason-lspconfig's auto-enable here to avoid a double start. Any other server
--- auto-enables. SPC c keymaps bind per-buffer on LspAttach for every LSP.
+-- LSP core (language-agnostic). mason installs servers, mason-lspconfig
+-- auto-enables the installed ones, blink's completion capabilities are
+-- advertised to every server, and the SPC c keymaps bind per-buffer on attach.
+--
+-- Language-specific setup lives in its own file, not here:
+--   Java       -> jdtls.lua      (nvim-jdtls; adds jdtls to mason, excludes it
+--                                  from auto-enable since nvim-jdtls starts it)
+--   TypeScript -> typescript.lua (ts_ls / eslint / tailwindcss for Next.js)
+-- Those files append their servers via opts FUNCTIONS that extend the lists in
+-- place (lazy REPLACES list-valued table opts on merge and runs fragments in
+-- filename order, so a base list here would be clobbered -- the language files
+-- own and initialise the lists defensively instead).
 return {
   {
     "williamboman/mason.nvim",
@@ -16,10 +23,7 @@ return {
       "williamboman/mason.nvim",
       "neovim/nvim-lspconfig",
     },
-    opts = {
-      ensure_installed = { "jdtls" }, -- still install the binary; nvim-jdtls runs it
-      automatic_enable = { exclude = { "jdtls" } }, -- jdtls is started by nvim-jdtls
-    },
+    opts = {}, -- ensure_installed / automatic_enable come from the language files
     config = function(_, opts)
       require("mason-lspconfig").setup(opts)
 

--- a/linux/.config/nvim/lua/plugins/project.lua
+++ b/linux/.config/nvim/lua/plugins/project.lua
@@ -1,6 +1,7 @@
 -- project.nvim: track project roots; open each project as its own tab.
 -- One project per tabpage, each with a tab-local cwd (:tcd).
 --   SPC p o  pick a known project -> opens in a NEW tab (oil at its root)
+--   SPC p n  pick a folder under ~/dev -> add to known projects (does not open)
 --   SPC p w  pick a git worktree of the current repo -> opens in a NEW tab
 --   SPC p q  close the current project (tabpage)
 --   Alt+1..9 switch to project (tab) N
@@ -160,6 +161,71 @@ return {
         :find()
     end
 
+    -- Register a folder as a known project WITHOUT opening it, so SPC p o can
+    -- open it later. Appends to project.nvim's history and persists it. Telescope
+    -- lists directories under ~/dev (2 levels deep, skipping hidden/build dirs).
+    local project_search_root = vim.fn.expand("~/dev")
+    local function add_project()
+      if vim.fn.isdirectory(project_search_root) == 0 then
+        vim.notify(project_search_root .. " does not exist", vim.log.levels.WARN)
+        return
+      end
+      local cmd
+      if vim.fn.executable("fd") == 1 then
+        cmd = { "fd", "--type", "d", "--max-depth", "2", "--absolute-path", "--color", "never", ".", project_search_root }
+      else
+        cmd = { "find", project_search_root, "-maxdepth", "2", "-type", "d" }
+      end
+      local items = {}
+      for _, d in ipairs(vim.fn.systemlist(cmd)) do
+        d = d:gsub("/+$", "")
+        if
+          d ~= project_search_root
+          and not d:find("/%.") -- skip hidden dirs (.git, ...)
+          and not d:find("/node_modules")
+          and not d:find("/target")
+          and not d:find("/build")
+        then
+          table.insert(items, d)
+        end
+      end
+      if vim.tbl_isempty(items) then
+        vim.notify("No folders found under " .. project_search_root, vim.log.levels.INFO)
+        return
+      end
+      local pickers = require("telescope.pickers")
+      local finders = require("telescope.finders")
+      local conf = require("telescope.config").values
+      local actions = require("telescope.actions")
+      local action_state = require("telescope.actions.state")
+      pickers
+        .new({}, {
+          prompt_title = "Add project (~/dev)",
+          finder = finders.new_table({ results = items }),
+          sorter = conf.generic_sorter({}),
+          attach_mappings = function(bufnr)
+            actions.select_default:replace(function()
+              actions.close(bufnr)
+              local entry = action_state.get_selected_entry()
+              local path = entry and entry[1]
+              if not path then
+                return
+              end
+              if vim.tbl_contains(require("project_nvim").get_recent_projects(), path) then
+                vim.notify("Already a known project: " .. path, vim.log.levels.INFO)
+                return
+              end
+              local history = require("project_nvim.utils.history")
+              table.insert(history.session_projects, path)
+              history.write_projects_to_history()
+              vim.notify("Added project: " .. path)
+            end)
+            return true
+          end,
+        })
+        :find()
+    end
+
     -- Tabline: show each tab's "Project (worktree)" label (set at open time),
     -- falling back to the tab-local cwd's dir name for tabs opened another way.
     function _G.ProjectTabline()
@@ -183,6 +249,7 @@ return {
     vim.o.showtabline = 2
 
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
+    vim.keymap.set("n", "<leader>pn", add_project, { desc = "Add project from ~/dev (no open)" })
     vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })
     vim.keymap.set("n", "<leader>pq", "<cmd>tabclose<CR>", { desc = "Close project (tab)" })
     for i = 1, 9 do

--- a/linux/.config/nvim/lua/plugins/treesitter.lua
+++ b/linux/.config/nvim/lua/plugins/treesitter.lua
@@ -2,7 +2,21 @@
 -- archived and unsupported on 0.11+). The main branch only manages parsers;
 -- highlighting is native via vim.treesitter.start(), wired per-buffer on
 -- FileType. Indentation uses the plugin's indentexpr.
-local ensure = { "java", "lua", "markdown", "markdown_inline", "vim", "vimdoc" }
+local ensure = {
+  "java",
+  "lua",
+  "markdown",
+  "markdown_inline",
+  "vim",
+  "vimdoc",
+  -- web / Next.js
+  "typescript",
+  "tsx",
+  "javascript",
+  "json",
+  "css",
+  "html",
+}
 
 return {
   "nvim-treesitter/nvim-treesitter",

--- a/linux/.config/nvim/lua/plugins/typescript.lua
+++ b/linux/.config/nvim/lua/plugins/typescript.lua
@@ -1,0 +1,26 @@
+-- TypeScript / JavaScript LSP, tuned for Next.js. All of TS's LSP config lives
+-- here (kept out of lsp.lua and jdtls.lua):
+--   ts_ls        TypeScript/JavaScript, incl. .tsx / .jsx (Next.js pages)
+--   eslint       linting + fixes (Next projects ship an eslint config)
+--   tailwindcss  Tailwind class completion/hover (attaches only when a Tailwind
+--                config is present, so it is inert on non-Tailwind projects)
+-- mason installs them and mason-lspconfig auto-enables them (see lsp.lua); the
+-- shared blink capabilities and SPC c keymaps apply. `SPC c f` formats via the
+-- LSP fallback (ts_ls / eslint). Treesitter web parsers come from treesitter.lua.
+return {
+  {
+    -- opts function that inits then extends in place (lazy replaces list-valued
+    -- table opts and runs fragments in filename order, so init defensively).
+    "williamboman/mason-lspconfig.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "ts_ls", "eslint", "tailwindcss" })
+    end,
+  },
+  {
+    -- Auto-close and auto-rename JSX/TSX/HTML tags (treesitter-driven).
+    "windwp/nvim-ts-autotag",
+    ft = { "html", "javascript", "javascriptreact", "typescript", "typescriptreact" },
+    opts = {},
+  },
+}

--- a/macbook/.config/nvim/lua/plugins/jdtls.lua
+++ b/macbook/.config/nvim/lua/plugins/jdtls.lua
@@ -3,9 +3,26 @@
 -- extendedClientCapabilities, which leaves jdtls degraded: diagnostics work but
 -- code actions do not. nvim-jdtls gives each project its own workspace and sets
 -- those capabilities, unlocking add-import / organize-imports / generate /
--- extract, etc. mason installs the jdtls binary (ensure_installed in lsp.lua);
--- this spec only starts it. jdtls stays excluded from auto-enable in lsp.lua.
-return {
+-- extract, etc. This file owns all of Java's LSP config: it installs the jdtls
+-- binary via mason and keeps it out of auto-enable (nvim-jdtls starts it), then
+-- drives nvim-jdtls itself.
+
+-- Java owns its mason entry: install jdtls, but let nvim-jdtls start it. An opts
+-- function that initialises the lists then extends them in place -- lazy runs
+-- fragments in filename order and replaces list-valued table opts, so each
+-- contributor must defensively init before extending.
+local mason_jdtls = {
+  "williamboman/mason-lspconfig.nvim",
+  opts = function(_, opts)
+    opts.ensure_installed = opts.ensure_installed or {}
+    opts.automatic_enable = opts.automatic_enable or {}
+    opts.automatic_enable.exclude = opts.automatic_enable.exclude or {}
+    vim.list_extend(opts.ensure_installed, { "jdtls" })
+    vim.list_extend(opts.automatic_enable.exclude, { "jdtls" })
+  end,
+}
+
+local nvim_jdtls = {
   "mfussenegger/nvim-jdtls",
   ft = "java",
   dependencies = { "williamboman/mason.nvim" },
@@ -87,3 +104,5 @@ return {
     end
   end,
 }
+
+return { mason_jdtls, nvim_jdtls }

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -1,8 +1,15 @@
--- LSP: mason installs language servers, nvim-lspconfig provides their configs.
--- Java (jdtls) is driven by nvim-jdtls (see jdtls.lua) for a per-project
--- workspace and the full code-action set, so it is excluded from
--- mason-lspconfig's auto-enable here to avoid a double start. Any other server
--- auto-enables. SPC c keymaps bind per-buffer on LspAttach for every LSP.
+-- LSP core (language-agnostic). mason installs servers, mason-lspconfig
+-- auto-enables the installed ones, blink's completion capabilities are
+-- advertised to every server, and the SPC c keymaps bind per-buffer on attach.
+--
+-- Language-specific setup lives in its own file, not here:
+--   Java       -> jdtls.lua      (nvim-jdtls; adds jdtls to mason, excludes it
+--                                  from auto-enable since nvim-jdtls starts it)
+--   TypeScript -> typescript.lua (ts_ls / eslint / tailwindcss for Next.js)
+-- Those files append their servers via opts FUNCTIONS that extend the lists in
+-- place (lazy REPLACES list-valued table opts on merge and runs fragments in
+-- filename order, so a base list here would be clobbered -- the language files
+-- own and initialise the lists defensively instead).
 return {
   {
     "williamboman/mason.nvim",
@@ -16,10 +23,7 @@ return {
       "williamboman/mason.nvim",
       "neovim/nvim-lspconfig",
     },
-    opts = {
-      ensure_installed = { "jdtls" }, -- still install the binary; nvim-jdtls runs it
-      automatic_enable = { exclude = { "jdtls" } }, -- jdtls is started by nvim-jdtls
-    },
+    opts = {}, -- ensure_installed / automatic_enable come from the language files
     config = function(_, opts)
       require("mason-lspconfig").setup(opts)
 

--- a/macbook/.config/nvim/lua/plugins/project.lua
+++ b/macbook/.config/nvim/lua/plugins/project.lua
@@ -1,6 +1,7 @@
 -- project.nvim: track project roots; open each project as its own tab.
 -- One project per tabpage, each with a tab-local cwd (:tcd).
 --   SPC p o  pick a known project -> opens in a NEW tab (oil at its root)
+--   SPC p n  pick a folder under ~/dev -> add to known projects (does not open)
 --   SPC p w  pick a git worktree of the current repo -> opens in a NEW tab
 --   SPC p q  close the current project (tabpage)
 --   Alt+1..9 switch to project (tab) N
@@ -160,6 +161,71 @@ return {
         :find()
     end
 
+    -- Register a folder as a known project WITHOUT opening it, so SPC p o can
+    -- open it later. Appends to project.nvim's history and persists it. Telescope
+    -- lists directories under ~/dev (2 levels deep, skipping hidden/build dirs).
+    local project_search_root = vim.fn.expand("~/dev")
+    local function add_project()
+      if vim.fn.isdirectory(project_search_root) == 0 then
+        vim.notify(project_search_root .. " does not exist", vim.log.levels.WARN)
+        return
+      end
+      local cmd
+      if vim.fn.executable("fd") == 1 then
+        cmd = { "fd", "--type", "d", "--max-depth", "2", "--absolute-path", "--color", "never", ".", project_search_root }
+      else
+        cmd = { "find", project_search_root, "-maxdepth", "2", "-type", "d" }
+      end
+      local items = {}
+      for _, d in ipairs(vim.fn.systemlist(cmd)) do
+        d = d:gsub("/+$", "")
+        if
+          d ~= project_search_root
+          and not d:find("/%.") -- skip hidden dirs (.git, ...)
+          and not d:find("/node_modules")
+          and not d:find("/target")
+          and not d:find("/build")
+        then
+          table.insert(items, d)
+        end
+      end
+      if vim.tbl_isempty(items) then
+        vim.notify("No folders found under " .. project_search_root, vim.log.levels.INFO)
+        return
+      end
+      local pickers = require("telescope.pickers")
+      local finders = require("telescope.finders")
+      local conf = require("telescope.config").values
+      local actions = require("telescope.actions")
+      local action_state = require("telescope.actions.state")
+      pickers
+        .new({}, {
+          prompt_title = "Add project (~/dev)",
+          finder = finders.new_table({ results = items }),
+          sorter = conf.generic_sorter({}),
+          attach_mappings = function(bufnr)
+            actions.select_default:replace(function()
+              actions.close(bufnr)
+              local entry = action_state.get_selected_entry()
+              local path = entry and entry[1]
+              if not path then
+                return
+              end
+              if vim.tbl_contains(require("project_nvim").get_recent_projects(), path) then
+                vim.notify("Already a known project: " .. path, vim.log.levels.INFO)
+                return
+              end
+              local history = require("project_nvim.utils.history")
+              table.insert(history.session_projects, path)
+              history.write_projects_to_history()
+              vim.notify("Added project: " .. path)
+            end)
+            return true
+          end,
+        })
+        :find()
+    end
+
     -- Tabline: show each tab's "Project (worktree)" label (set at open time),
     -- falling back to the tab-local cwd's dir name for tabs opened another way.
     function _G.ProjectTabline()
@@ -183,6 +249,7 @@ return {
     vim.o.showtabline = 2
 
     vim.keymap.set("n", "<leader>po", pick_project, { desc = "Open project (new tab)" })
+    vim.keymap.set("n", "<leader>pn", add_project, { desc = "Add project from ~/dev (no open)" })
     vim.keymap.set("n", "<leader>pw", pick_worktree, { desc = "Switch git worktree (new tab)" })
     vim.keymap.set("n", "<leader>pq", "<cmd>tabclose<CR>", { desc = "Close project (tab)" })
     for i = 1, 9 do

--- a/macbook/.config/nvim/lua/plugins/treesitter.lua
+++ b/macbook/.config/nvim/lua/plugins/treesitter.lua
@@ -2,7 +2,21 @@
 -- archived and unsupported on 0.11+). The main branch only manages parsers;
 -- highlighting is native via vim.treesitter.start(), wired per-buffer on
 -- FileType. Indentation uses the plugin's indentexpr.
-local ensure = { "java", "lua", "markdown", "markdown_inline", "vim", "vimdoc" }
+local ensure = {
+  "java",
+  "lua",
+  "markdown",
+  "markdown_inline",
+  "vim",
+  "vimdoc",
+  -- web / Next.js
+  "typescript",
+  "tsx",
+  "javascript",
+  "json",
+  "css",
+  "html",
+}
 
 return {
   "nvim-treesitter/nvim-treesitter",

--- a/macbook/.config/nvim/lua/plugins/typescript.lua
+++ b/macbook/.config/nvim/lua/plugins/typescript.lua
@@ -1,0 +1,26 @@
+-- TypeScript / JavaScript LSP, tuned for Next.js. All of TS's LSP config lives
+-- here (kept out of lsp.lua and jdtls.lua):
+--   ts_ls        TypeScript/JavaScript, incl. .tsx / .jsx (Next.js pages)
+--   eslint       linting + fixes (Next projects ship an eslint config)
+--   tailwindcss  Tailwind class completion/hover (attaches only when a Tailwind
+--                config is present, so it is inert on non-Tailwind projects)
+-- mason installs them and mason-lspconfig auto-enables them (see lsp.lua); the
+-- shared blink capabilities and SPC c keymaps apply. `SPC c f` formats via the
+-- LSP fallback (ts_ls / eslint). Treesitter web parsers come from treesitter.lua.
+return {
+  {
+    -- opts function that inits then extends in place (lazy replaces list-valued
+    -- table opts and runs fragments in filename order, so init defensively).
+    "williamboman/mason-lspconfig.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "ts_ls", "eslint", "tailwindcss" })
+    end,
+  },
+  {
+    -- Auto-close and auto-rename JSX/TSX/HTML tags (treesitter-driven).
+    "windwp/nvim-ts-autotag",
+    ft = { "html", "javascript", "javascriptreact", "typescript", "typescriptreact" },
+    opts = {},
+  },
+}


### PR DESCRIPTION
## What

1. `SPC p n` — pick a folder under `~/dev` in telescope and register it as a known project (project.nvim), **without opening it**, so `SPC p o` can open it later.
2. TypeScript LSP for Next.js, and a split of the LSP config so Java and TypeScript never mix.

## add-project (SPC p n)

- Lists dirs under `~/dev` (2 levels, `fd`/`find`), skipping hidden/`node_modules`/`target`/`build`.
- On select: appends to project.nvim's `history.session_projects` + persists. No cd, no tab.

## TypeScript LSP + language split

- **lsp.lua** is now language-agnostic: mason, blink capabilities, `SPC c` keymaps, `mason-lspconfig` setup. No server names.
- **jdtls.lua** (Java) owns its mason install (`jdtls`) and the auto-enable exclude, plus nvim-jdtls.
- **typescript.lua** (new) owns `ts_ls` + `eslint` + `tailwindcss` for Next.js, plus `nvim-ts-autotag` for JSX/TSX tag close/rename.
- Each language file appends its servers via an **opts function** (lazy replaces list-valued table opts on merge and runs fragments in filename order, so contributions extend the lists in place).
- **treesitter** gains `typescript`, `tsx`, `javascript`, `json`, `css`, `html` parsers.

The shared `SPC c d/D/a/f` keymaps + blink completion apply to TS the same as Java.

## Verified

- add-project: keymap binds; `~/dev` listing works; an added folder appears in `get_recent_projects()` (isolated, no real-history pollution).
- LSP split: resolved `mason-lspconfig` opts merge to `ensure_installed = jdtls, ts_ls, eslint, tailwindcss` and `automatic_enable.exclude = jdtls` — confirming all four servers install and jdtls stays hand-managed.
- All 8 changed Lua files parse on both platforms.

## Runtime deps (install-time)

TS servers run on Node (already present via nvm). `tree-sitter` CLI (already installed) builds the new web parsers on first launch.

macbook + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)