### PR TITLE
feat(nvim): tab number in tab label

### DIFF
--- a/linux/.config/nvim/lua/plugins/project.lua
+++ b/linux/.config/nvim/lua/plugins/project.lua
@@ -239,7 +239,8 @@ return {
           label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
         end
         label = label:gsub("%%", "%%%%") -- escape for the statusline parser
-        parts[#parts + 1] = hl .. "%" .. i .. "T " .. label .. " "
+        -- prefix the tab number (also its Alt+<n> switch key)
+        parts[#parts + 1] = hl .. "%" .. i .. "T " .. i .. ": " .. label .. " "
       end
       parts[#parts + 1] = "%#TabLineFill#%T"
       return table.concat(parts)

--- a/macbook/.config/nvim/lua/plugins/project.lua
+++ b/macbook/.config/nvim/lua/plugins/project.lua
@@ -239,7 +239,8 @@ return {
           label = (cwd ~= "" and vim.fn.fnamemodify(cwd, ":t")) or "[No Name]"
         end
         label = label:gsub("%%", "%%%%") -- escape for the statusline parser
-        parts[#parts + 1] = hl .. "%" .. i .. "T " .. label .. " "
+        -- prefix the tab number (also its Alt+<n> switch key)
+        parts[#parts + 1] = hl .. "%" .. i .. "T " .. i .. ": " .. label .. " "
       end
       parts[#parts + 1] = "%#TabLineFill#%T"
       return table.concat(parts)


### PR DESCRIPTION
## What

Show the tab number in each tab's label on the tabline: `1: ProjectX`, `2: api (wt-feature)`.

## Why

The number is also the tab's `Alt+<n>` switch key, so surfacing it makes the switch shortcut discoverable at a glance.

## How

One line in `project.lua`'s `ProjectTabline`: prefix `i .. ": "` before the label (still inside the `%<i>T` click region).

## Verified

Rendered headless: `%#TabLine#%1T 1: ProjectX %#TabLineSel#%2T 2: api (wt-feature) %#TabLineFill#%T`. Syntax clean, both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)