### PR TITLE
feat(nvim): neogit opens in same tab

### DIFF
--- a/linux/.config/nvim/lua/plugins/neogit.lua
+++ b/linux/.config/nvim/lua/plugins/neogit.lua
@@ -10,5 +10,9 @@ return {
   keys = {
     { "<leader>gg", "<cmd>Neogit<CR>", desc = "Neogit status" },
   },
-  opts = {},
+  opts = {
+    -- Open the status in the current window (same project tab) instead of a new
+    -- tab. Neogit restores the previous buffer when the status is closed.
+    kind = "replace",
+  },
 }

--- a/macbook/.config/nvim/lua/plugins/neogit.lua
+++ b/macbook/.config/nvim/lua/plugins/neogit.lua
@@ -10,5 +10,9 @@ return {
   keys = {
     { "<leader>gg", "<cmd>Neogit<CR>", desc = "Neogit status" },
   },
-  opts = {},
+  opts = {
+    -- Open the status in the current window (same project tab) instead of a new
+    -- tab. Neogit restores the previous buffer when the status is closed.
+    kind = "replace",
+  },
 }


### PR DESCRIPTION
## What

`SPC g g` (Neogit) now opens in the current window — the same project tab — instead of a new tab.

## How

Neogit's default `kind` is `"tab"`. Set `kind = "replace"` in its opts, so the status opens in the current window and restores the previous buffer when closed.

## Verified

Headless in a git repo: tab count stays 1 after opening Neogit (no new tab), and the current window shows the `NeogitStatus` buffer. Config resolves `kind = replace`. Syntax clean, both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)