### PR TITLE
fix(nvim): SPC c f global + spotless fallback to jdtls

### DIFF
--- a/linux/.config/nvim/lua/plugins/conform.lua
+++ b/linux/.config/nvim/lua/plugins/conform.lua
@@ -44,16 +44,29 @@ return {
     return {
       formatters = {
         spotless = {
-          command = "./gradlew",
-          args = {
-            "spotlessApply",
-            "-PspotlessIdeHook=$FILENAME",
-            "-PspotlessIdeHookUseStdIn",
-            "-PspotlessIdeHookUseStdOut",
-            "--quiet",
-          },
+          -- Absolute gradlew path: conform's "is the command executable" check
+          -- runs against Neovim's cwd, not the formatter's cwd, so a relative
+          -- "./gradlew" is skipped whenever cwd isn't the Gradle root (e.g. the
+          -- project tab is rooted at the repo, and gradlew lives in a subdir).
+          command = function(_, ctx)
+            local root = vim.fs.root(ctx.filename, { "settings.gradle", "settings.gradle.kts", "gradlew" })
+            return (root or ".") .. "/gradlew"
+          end,
+          -- args as a function: conform only expands a bare "$FILENAME" arg, not
+          -- one embedded in "-PspotlessIdeHook=$FILENAME", so build it here with
+          -- the real path -- else Spotless gets a bogus hook target, treats the
+          -- input as clean, and returns empty (conform then aborts).
+          args = function(_, ctx)
+            return {
+              "spotlessApply",
+              "-PspotlessIdeHook=" .. ctx.filename,
+              "-PspotlessIdeHookUseStdIn",
+              "-PspotlessIdeHookUseStdOut",
+              "--quiet",
+            }
+          end,
           stdin = true,
-          -- ./gradlew must run from the Gradle root.
+          -- gradlew must still RUN from the Gradle root.
           cwd = util.root_file({ "settings.gradle", "settings.gradle.kts", "gradlew" }),
           require_cwd = true,
           condition = function(_, ctx)

--- a/linux/.config/nvim/lua/plugins/conform.lua
+++ b/linux/.config/nvim/lua/plugins/conform.lua
@@ -1,12 +1,44 @@
--- Formatting via conform.nvim. Java is formatted by the project's own Spotless,
--- so the result matches `gradlew spotlessCheck` exactly -- including its import
--- order -- rather than jdtls's Eclipse formatter. Spotless's IDE hook reads the
--- buffer on stdin and returns the formatted text on stdout. It runs only when a
--- Gradle root is found; otherwise (and for every non-Java filetype) SPC c f
--- falls back to the LSP formatter. SPC c f is bound in lsp.lua.
+-- Formatting via conform.nvim. Java is formatted by the project's own Spotless
+-- when the project configures it, so the result matches `gradlew spotlessCheck`
+-- exactly -- including its import order -- rather than jdtls's Eclipse formatter.
+-- Spotless's IDE hook reads the buffer on stdin and returns the formatted text
+-- on stdout. When the project has no Spotless (or the file is not in a Gradle
+-- project), conform skips Java and SPC c f falls back to the LSP (jdtls)
+-- formatter. SPC c f is a GLOBAL keymap defined here (not LspAttach-bound), so
+-- it works even before/without an LSP attaching.
+
+-- Enable Spotless only for Gradle projects that actually configure it: walk up
+-- from the file and look for "spotless" in a build.gradle(.kts). Otherwise the
+-- gradlew spotlessApply task doesn't exist and would error with no fallback.
+local function has_spotless(ctx)
+  local builds = vim.fs.find({ "build.gradle", "build.gradle.kts" }, {
+    path = vim.fs.dirname(ctx.filename),
+    upward = true,
+    limit = math.huge,
+  })
+  for _, b in ipairs(builds) do
+    local ok, lines = pcall(vim.fn.readfile, b)
+    if ok and table.concat(lines, "\n"):find("spotless", 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
 return {
   "stevearc/conform.nvim",
-  lazy = true,
+  keys = {
+    {
+      "<leader>cf",
+      function()
+        -- Java -> Spotless (conform); other filetypes / no-Spotless projects
+        -- fall back to the LSP formatter.
+        require("conform").format({ async = true, lsp_format = "fallback" })
+      end,
+      mode = { "n", "v" },
+      desc = "Format buffer",
+    },
+  },
   opts = function()
     local util = require("conform.util")
     return {
@@ -21,11 +53,12 @@ return {
             "--quiet",
           },
           stdin = true,
-          -- ./gradlew must run from the Gradle root; require_cwd skips Spotless
-          -- (so SPC c f falls back to the LSP formatter) when the file is not
-          -- inside a Gradle project.
+          -- ./gradlew must run from the Gradle root.
           cwd = util.root_file({ "settings.gradle", "settings.gradle.kts", "gradlew" }),
           require_cwd = true,
+          condition = function(_, ctx)
+            return has_spotless(ctx)
+          end,
         },
       },
       formatters_by_ft = {

--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -43,10 +43,8 @@ return {
           m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
           m("<leader>cD", "<cmd>Telescope lsp_references<CR>", "Find usages")
           m("<leader>ca", vim.lsp.buf.code_action, "Code action")
-          m("<leader>cf", function()
-            -- Java -> Spotless (conform); other filetypes fall back to the LSP.
-            require("conform").format({ async = true, lsp_format = "fallback" })
-          end, "Format buffer")
+          -- SPC c f (format) is a global keymap in conform.lua so it works even
+          -- without an LSP attached.
         end,
       })
     end,

--- a/macbook/.config/nvim/lua/plugins/conform.lua
+++ b/macbook/.config/nvim/lua/plugins/conform.lua
@@ -44,16 +44,29 @@ return {
     return {
       formatters = {
         spotless = {
-          command = "./gradlew",
-          args = {
-            "spotlessApply",
-            "-PspotlessIdeHook=$FILENAME",
-            "-PspotlessIdeHookUseStdIn",
-            "-PspotlessIdeHookUseStdOut",
-            "--quiet",
-          },
+          -- Absolute gradlew path: conform's "is the command executable" check
+          -- runs against Neovim's cwd, not the formatter's cwd, so a relative
+          -- "./gradlew" is skipped whenever cwd isn't the Gradle root (e.g. the
+          -- project tab is rooted at the repo, and gradlew lives in a subdir).
+          command = function(_, ctx)
+            local root = vim.fs.root(ctx.filename, { "settings.gradle", "settings.gradle.kts", "gradlew" })
+            return (root or ".") .. "/gradlew"
+          end,
+          -- args as a function: conform only expands a bare "$FILENAME" arg, not
+          -- one embedded in "-PspotlessIdeHook=$FILENAME", so build it here with
+          -- the real path -- else Spotless gets a bogus hook target, treats the
+          -- input as clean, and returns empty (conform then aborts).
+          args = function(_, ctx)
+            return {
+              "spotlessApply",
+              "-PspotlessIdeHook=" .. ctx.filename,
+              "-PspotlessIdeHookUseStdIn",
+              "-PspotlessIdeHookUseStdOut",
+              "--quiet",
+            }
+          end,
           stdin = true,
-          -- ./gradlew must run from the Gradle root.
+          -- gradlew must still RUN from the Gradle root.
           cwd = util.root_file({ "settings.gradle", "settings.gradle.kts", "gradlew" }),
           require_cwd = true,
           condition = function(_, ctx)

--- a/macbook/.config/nvim/lua/plugins/conform.lua
+++ b/macbook/.config/nvim/lua/plugins/conform.lua
@@ -1,12 +1,44 @@
--- Formatting via conform.nvim. Java is formatted by the project's own Spotless,
--- so the result matches `gradlew spotlessCheck` exactly -- including its import
--- order -- rather than jdtls's Eclipse formatter. Spotless's IDE hook reads the
--- buffer on stdin and returns the formatted text on stdout. It runs only when a
--- Gradle root is found; otherwise (and for every non-Java filetype) SPC c f
--- falls back to the LSP formatter. SPC c f is bound in lsp.lua.
+-- Formatting via conform.nvim. Java is formatted by the project's own Spotless
+-- when the project configures it, so the result matches `gradlew spotlessCheck`
+-- exactly -- including its import order -- rather than jdtls's Eclipse formatter.
+-- Spotless's IDE hook reads the buffer on stdin and returns the formatted text
+-- on stdout. When the project has no Spotless (or the file is not in a Gradle
+-- project), conform skips Java and SPC c f falls back to the LSP (jdtls)
+-- formatter. SPC c f is a GLOBAL keymap defined here (not LspAttach-bound), so
+-- it works even before/without an LSP attaching.
+
+-- Enable Spotless only for Gradle projects that actually configure it: walk up
+-- from the file and look for "spotless" in a build.gradle(.kts). Otherwise the
+-- gradlew spotlessApply task doesn't exist and would error with no fallback.
+local function has_spotless(ctx)
+  local builds = vim.fs.find({ "build.gradle", "build.gradle.kts" }, {
+    path = vim.fs.dirname(ctx.filename),
+    upward = true,
+    limit = math.huge,
+  })
+  for _, b in ipairs(builds) do
+    local ok, lines = pcall(vim.fn.readfile, b)
+    if ok and table.concat(lines, "\n"):find("spotless", 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
 return {
   "stevearc/conform.nvim",
-  lazy = true,
+  keys = {
+    {
+      "<leader>cf",
+      function()
+        -- Java -> Spotless (conform); other filetypes / no-Spotless projects
+        -- fall back to the LSP formatter.
+        require("conform").format({ async = true, lsp_format = "fallback" })
+      end,
+      mode = { "n", "v" },
+      desc = "Format buffer",
+    },
+  },
   opts = function()
     local util = require("conform.util")
     return {
@@ -21,11 +53,12 @@ return {
             "--quiet",
           },
           stdin = true,
-          -- ./gradlew must run from the Gradle root; require_cwd skips Spotless
-          -- (so SPC c f falls back to the LSP formatter) when the file is not
-          -- inside a Gradle project.
+          -- ./gradlew must run from the Gradle root.
           cwd = util.root_file({ "settings.gradle", "settings.gradle.kts", "gradlew" }),
           require_cwd = true,
+          condition = function(_, ctx)
+            return has_spotless(ctx)
+          end,
         },
       },
       formatters_by_ft = {

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -43,10 +43,8 @@ return {
           m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
           m("<leader>cD", "<cmd>Telescope lsp_references<CR>", "Find usages")
           m("<leader>ca", vim.lsp.buf.code_action, "Code action")
-          m("<leader>cf", function()
-            -- Java -> Spotless (conform); other filetypes fall back to the LSP.
-            require("conform").format({ async = true, lsp_format = "fallback" })
-          end, "Format buffer")
+          -- SPC c f (format) is a global keymap in conform.lua so it works even
+          -- without an LSP attached.
         end,
       })
     end,


### PR DESCRIPTION
## What

`SPC c f` wasn't formatting in two situations. Both fixed.

## Root causes

1. **Bound only on LspAttach.** The format keymap was buffer-local and set only when an LSP attached, so it did nothing on any buffer without an attached (or not-yet-attached) LSP — common in large multi-module Gradle/Quarkus projects, or on loose files.
2. **Spotless selected even when absent.** conform runs Spotless for any Gradle project. On a project without Spotless (e.g. `campaign-optimizer`), `gradlew spotlessApply` fails with `Task 'spotlessApply' not found`, and conform does **not** fall back to the LSP because a formatter *was* selected (it just errored).

## Fix

- `SPC c f` is now a **global** keymap in `conform.lua` (works with or without an LSP; also enabled in visual mode for range formatting).
- Spotless gets a `condition`: it runs only when a `build.gradle(.kts)` up the tree actually configures `spotless`. Otherwise conform skips Java → `lsp_format = "fallback"` → jdtls formats.

## Verified

- `has_spotless`: `absolute-house-control` (Spotless in `backend/quarkus/build.gradle.kts`) → **true**; `optimizer/workspace-1` (no Spotless) → **false**.
- Spotless IDE hook confirmed working in absolute-house-control (dirty stdin → formatted stdout).
- `SPC c f` binds even with no LSP/file open.
- Syntax clean, both platforms.

macbook + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)