### PR TITLE
fix(nvim): jdtls roots at multi-module gradle/maven root

### DIFF
--- a/linux/.config/nvim/lua/plugins/jdtls.lua
+++ b/linux/.config/nvim/lua/plugins/jdtls.lua
@@ -48,18 +48,38 @@ local nvim_jdtls = {
 
     local jdtls_bin = vim.fn.stdpath("data") .. "/mason/bin/jdtls"
 
-    local function start()
-      local jdtls = require("jdtls")
-      local root = vim.fs.root(0, {
-        "pom.xml",
-        "build.gradle",
-        "build.gradle.kts",
+    -- Root the LSP at the OUTERMOST project dir so multi-module Gradle/Maven
+    -- builds resolve cross-module types. settings.gradle(.kts), gradlew and mvnw
+    -- live only at the true root, so prefer them over a submodule's own
+    -- build.gradle / pom.xml (which vim.fs.root would otherwise pick because it
+    -- is nearer). Fall back to the topmost build file, then .git.
+    local function project_root(bufnr)
+      local single = vim.fs.root(bufnr, {
         "settings.gradle",
         "settings.gradle.kts",
-        "mvnw",
         "gradlew",
-        ".git",
+        "mvnw",
       })
+      if single then
+        return single
+      end
+      -- No wrapper/settings: climb to the topmost dir that still has a build
+      -- file (covers multi-module Maven, where every module has a pom.xml).
+      local markers = { "pom.xml", "build.gradle", "build.gradle.kts" }
+      local root = vim.fs.root(bufnr, markers)
+      while root do
+        local up = vim.fs.root(vim.fs.dirname(root), markers)
+        if not up or up == root then
+          break
+        end
+        root = up
+      end
+      return root or vim.fs.root(bufnr, { ".git" })
+    end
+
+    local function start()
+      local jdtls = require("jdtls")
+      local root = project_root(0)
       if not root then
         return -- loose file, not in a project: skip rather than spawn a stray workspace
       end

--- a/macbook/.config/nvim/lua/plugins/jdtls.lua
+++ b/macbook/.config/nvim/lua/plugins/jdtls.lua
@@ -48,18 +48,38 @@ local nvim_jdtls = {
 
     local jdtls_bin = vim.fn.stdpath("data") .. "/mason/bin/jdtls"
 
-    local function start()
-      local jdtls = require("jdtls")
-      local root = vim.fs.root(0, {
-        "pom.xml",
-        "build.gradle",
-        "build.gradle.kts",
+    -- Root the LSP at the OUTERMOST project dir so multi-module Gradle/Maven
+    -- builds resolve cross-module types. settings.gradle(.kts), gradlew and mvnw
+    -- live only at the true root, so prefer them over a submodule's own
+    -- build.gradle / pom.xml (which vim.fs.root would otherwise pick because it
+    -- is nearer). Fall back to the topmost build file, then .git.
+    local function project_root(bufnr)
+      local single = vim.fs.root(bufnr, {
         "settings.gradle",
         "settings.gradle.kts",
-        "mvnw",
         "gradlew",
-        ".git",
+        "mvnw",
       })
+      if single then
+        return single
+      end
+      -- No wrapper/settings: climb to the topmost dir that still has a build
+      -- file (covers multi-module Maven, where every module has a pom.xml).
+      local markers = { "pom.xml", "build.gradle", "build.gradle.kts" }
+      local root = vim.fs.root(bufnr, markers)
+      while root do
+        local up = vim.fs.root(vim.fs.dirname(root), markers)
+        if not up or up == root then
+          break
+        end
+        root = up
+      end
+      return root or vim.fs.root(bufnr, { ".git" })
+    end
+
+    local function start()
+      local jdtls = require("jdtls")
+      local root = project_root(0)
       if not root then
         return -- loose file, not in a project: skip rather than spawn a stray workspace
       end


### PR DESCRIPTION
## What

jdtls now roots at the outermost project directory, so multi-module Gradle/Maven builds resolve cross-module types.

## Root cause

`vim.fs.root` returns the **nearest** ancestor with a marker, and `build.gradle` / `pom.xml` exist in every submodule. So opening `metadata-next/optimizer/.../Foo.java` rooted jdtls at `optimizer/` (its own `build.gradle`) instead of the real Gradle+git root `metadata-next/` (which has `settings.gradle` + `gradlew` + `.git`). jdtls attaches but treats the submodule as standalone — no cross-module completion/diagnostics.

## Fix

`project_root()`:
1. Prefer `settings.gradle(.kts)` / `gradlew` / `mvnw` — these live only at the true root.
2. Else climb to the **topmost** dir that still has a build file (multi-module Maven, where every module has a `pom.xml`).
3. Fall back to `.git`.

## Verified

- `metadata-next/optimizer` → `metadata-next` (was `optimizer`).
- `absolute-house-control` → `backend/quarkus` (the Gradle root, not the repo root).
- End-to-end: opening the optimizer test file attaches jdtls with `root = metadata-next`.

macbook + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)