### PR TITLE
feat(nvim): autocomplete delay + toml/gradle support

### DIFF
--- a/linux/.config/nvim/lua/plugins/blink.lua
+++ b/linux/.config/nvim/lua/plugins/blink.lua
@@ -15,7 +15,7 @@ return {
       default = { "lsp", "path", "snippets", "buffer" },
     },
     completion = {
-      menu = { auto_show_delay_ms = 2000 }, -- wait 2s before auto-opening menu
+      menu = { auto_show_delay_ms = 500 }, -- wait 500ms before auto-opening menu
       documentation = { auto_show = true },
     },
   },

--- a/linux/.config/nvim/lua/plugins/conform.lua
+++ b/linux/.config/nvim/lua/plugins/conform.lua
@@ -76,6 +76,7 @@ return {
       },
       formatters_by_ft = {
         java = { "spotless" },
+        groovy = { "spotless" }, -- build.gradle, when the project's Spotless targets it
       },
     }
   end,

--- a/linux/.config/nvim/lua/plugins/gradle.lua
+++ b/linux/.config/nvim/lua/plugins/gradle.lua
@@ -1,0 +1,15 @@
+-- Gradle build scripts. build.gradle is Groovy (filetype "groovy"); groovyls
+-- provides language-level completion and hover. NOTE: no Neovim LSP understands
+-- the Gradle DSL the way IntelliJ does, so completion is Groovy-language level,
+-- not Gradle-plugin aware. build.gradle.kts (Kotlin) is not covered here.
+-- Formatting is handled by Spotless in conform.lua (groovy -> spotless) when the
+-- project configures Spotless for Gradle files. mason installs groovyls (a JVM
+-- app -- needs a JDK, already required by jdtls) and mason-lspconfig auto-enables
+-- it (see lsp.lua). Parser: see treesitter.lua (groovy).
+return {
+  "williamboman/mason-lspconfig.nvim",
+  opts = function(_, opts)
+    opts.ensure_installed = opts.ensure_installed or {}
+    vim.list_extend(opts.ensure_installed, { "groovyls" })
+  end,
+}

--- a/linux/.config/nvim/lua/plugins/toml.lua
+++ b/linux/.config/nvim/lua/plugins/toml.lua
@@ -1,0 +1,15 @@
+-- TOML support via taplo (Even Better TOML). Provides completion, hover, schema
+-- validation and formatting for .toml files -- including Gradle's version catalog
+-- (gradle/libs.versions.toml). mason installs taplo and mason-lspconfig
+-- auto-enables it (see lsp.lua); the shared blink capabilities and SPC c keymaps
+-- apply. SPC c f formats TOML via conform's LSP fallback (taplo). Parser: see
+-- treesitter.lua (toml).
+return {
+  -- opts function that inits then extends in place (lazy replaces list-valued
+  -- table opts and runs fragments in filename order, so init defensively).
+  "williamboman/mason-lspconfig.nvim",
+  opts = function(_, opts)
+    opts.ensure_installed = opts.ensure_installed or {}
+    vim.list_extend(opts.ensure_installed, { "taplo" })
+  end,
+}

--- a/linux/.config/nvim/lua/plugins/treesitter.lua
+++ b/linux/.config/nvim/lua/plugins/treesitter.lua
@@ -9,6 +9,9 @@ local ensure = {
   "markdown_inline",
   "vim",
   "vimdoc",
+  -- build tooling
+  "groovy", -- build.gradle
+  "toml", -- libs.versions.toml, *.toml
   -- web / Next.js
   "typescript",
   "tsx",

--- a/macbook/.config/nvim/lua/plugins/blink.lua
+++ b/macbook/.config/nvim/lua/plugins/blink.lua
@@ -15,7 +15,7 @@ return {
       default = { "lsp", "path", "snippets", "buffer" },
     },
     completion = {
-      menu = { auto_show_delay_ms = 2000 }, -- wait 2s before auto-opening menu
+      menu = { auto_show_delay_ms = 500 }, -- wait 500ms before auto-opening menu
       documentation = { auto_show = true },
     },
   },

--- a/macbook/.config/nvim/lua/plugins/conform.lua
+++ b/macbook/.config/nvim/lua/plugins/conform.lua
@@ -76,6 +76,7 @@ return {
       },
       formatters_by_ft = {
         java = { "spotless" },
+        groovy = { "spotless" }, -- build.gradle, when the project's Spotless targets it
       },
     }
   end,

--- a/macbook/.config/nvim/lua/plugins/gradle.lua
+++ b/macbook/.config/nvim/lua/plugins/gradle.lua
@@ -1,0 +1,15 @@
+-- Gradle build scripts. build.gradle is Groovy (filetype "groovy"); groovyls
+-- provides language-level completion and hover. NOTE: no Neovim LSP understands
+-- the Gradle DSL the way IntelliJ does, so completion is Groovy-language level,
+-- not Gradle-plugin aware. build.gradle.kts (Kotlin) is not covered here.
+-- Formatting is handled by Spotless in conform.lua (groovy -> spotless) when the
+-- project configures Spotless for Gradle files. mason installs groovyls (a JVM
+-- app -- needs a JDK, already required by jdtls) and mason-lspconfig auto-enables
+-- it (see lsp.lua). Parser: see treesitter.lua (groovy).
+return {
+  "williamboman/mason-lspconfig.nvim",
+  opts = function(_, opts)
+    opts.ensure_installed = opts.ensure_installed or {}
+    vim.list_extend(opts.ensure_installed, { "groovyls" })
+  end,
+}

--- a/macbook/.config/nvim/lua/plugins/toml.lua
+++ b/macbook/.config/nvim/lua/plugins/toml.lua
@@ -1,0 +1,15 @@
+-- TOML support via taplo (Even Better TOML). Provides completion, hover, schema
+-- validation and formatting for .toml files -- including Gradle's version catalog
+-- (gradle/libs.versions.toml). mason installs taplo and mason-lspconfig
+-- auto-enables it (see lsp.lua); the shared blink capabilities and SPC c keymaps
+-- apply. SPC c f formats TOML via conform's LSP fallback (taplo). Parser: see
+-- treesitter.lua (toml).
+return {
+  -- opts function that inits then extends in place (lazy replaces list-valued
+  -- table opts and runs fragments in filename order, so init defensively).
+  "williamboman/mason-lspconfig.nvim",
+  opts = function(_, opts)
+    opts.ensure_installed = opts.ensure_installed or {}
+    vim.list_extend(opts.ensure_installed, { "taplo" })
+  end,
+}

--- a/macbook/.config/nvim/lua/plugins/treesitter.lua
+++ b/macbook/.config/nvim/lua/plugins/treesitter.lua
@@ -9,6 +9,9 @@ local ensure = {
   "markdown_inline",
   "vim",
   "vimdoc",
+  -- build tooling
+  "groovy", -- build.gradle
+  "toml", -- libs.versions.toml, *.toml
   -- web / Next.js
   "typescript",
   "tsx",


### PR DESCRIPTION
## what

bundled (per request):

### 1. autocomplete delay 2s -> 500ms
blink menu auto-open after 500ms. ctrl+space still instant.

### 2. TOML support (taplo)
- **taplo** LSP: complete, hover, schema validate, **format**. cover `*.toml` + gradle `libs.versions.toml`.
- SPC c f format toml via conform LSP fallback.

### 3. build.gradle support (groovy)
- **groovyls** LSP: complete + hover for `build.gradle` (filetype groovy).
- format via **spotless** (conform `groovy -> spotless`) when the project spotless target gradle file.
- **caveat**: no nvim LSP know the gradle DSL like intellij. groovyls give groovy-language complete, not gradle-plugin aware. `build.gradle.kts` (kotlin) not cover here.

### treesitter
add `groovy` + `toml` parser for highlight.

## files

- `toml.lua`, `gradle.lua` (new, mac + linux) — add taplo / groovyls to mason
- `conform.lua` (mac + linux) — groovy -> spotless
- `treesitter.lua` (mac + linux) — add parsers
- `blink.lua` (mac + linux) — 500ms delay

restart nvim -> mason install taplo + groovyls, treesitter build parsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)