### PR TITLE
feat(nvim): java indent 4 spaces (match spotless)

### DIFF
--- a/linux/.config/nvim/ftplugin/java.lua
+++ b/linux/.config/nvim/ftplugin/java.lua
@@ -1,0 +1,9 @@
+-- Java indentation matched to Spotless so hand-typed code stays
+-- spotless-compliant: 4 spaces, no tabs. Buffer-local; overrides the 2-space
+-- global default from config/options.lua. If your project's Spotless uses a
+-- different width -- google-java-format is 2 spaces, or an Eclipse config may
+-- use real tabs -- adjust the numbers (or set expandtab = false) here.
+vim.bo.expandtab = true
+vim.bo.shiftwidth = 4
+vim.bo.tabstop = 4
+vim.bo.softtabstop = 4

--- a/macbook/.config/nvim/ftplugin/java.lua
+++ b/macbook/.config/nvim/ftplugin/java.lua
@@ -1,0 +1,9 @@
+-- Java indentation matched to Spotless so hand-typed code stays
+-- spotless-compliant: 4 spaces, no tabs. Buffer-local; overrides the 2-space
+-- global default from config/options.lua. If your project's Spotless uses a
+-- different width -- google-java-format is 2 spaces, or an Eclipse config may
+-- use real tabs -- adjust the numbers (or set expandtab = false) here.
+vim.bo.expandtab = true
+vim.bo.shiftwidth = 4
+vim.bo.tabstop = 4
+vim.bo.softtabstop = 4


### PR DESCRIPTION
## what

`.java` file now indent **4 spaces** (no tabs), match the common spotless / eclipse / palantir / quarkus default. so hand-typed java stay spotless-compliant.

- new `ftplugin/java.lua` (mac + linux): buffer-local `expandtab`, `shiftwidth/tabstop/softtabstop = 4`. override the 2-space global (options.lua) only for java.

## why 4

your global indent is already 2 space; you want a change for java -> so your spotless is not the 2-space google-java-format. 4 is the common default.

## if wrong

if your spotless actually use 2 space (googleJavaFormat) or real tabs (some eclipse config), it one line: change the numbers or set `expandtab = false` in `ftplugin/java.lua`. quick check: open an already-formatted `.java`, look at one indent level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)