### PR TITLE
feat(nvim): SPC j build + refresh-deps, refresh jdtls

### DIFF
--- a/linux/.config/nvim/lua/config/build.lua
+++ b/linux/.config/nvim/lua/config/build.lua
@@ -1,12 +1,18 @@
--- Async project build with a statusline progress indicator. SPC c b (mapped in
--- config/keymaps.lua) runs the project's build tool -- gradle / maven / npm,
--- auto-detected from the root -- as a background job. A spinner takes over the
--- statusline while it runs, then shows OK / FAILED for a few seconds. On failure
--- the captured output goes to the quickfix list (:copen) so errors are navigable.
+-- Async Gradle/Maven/npm actions with a statusline progress indicator, plus a
+-- jdtls cache refresh so the Java LSP re-imports afterwards. Bound in
+-- config/keymaps.lua under SPC j (java):
+--   SPC j b  build the project (gradle: build -x test)
+--   SPC j d  refresh Gradle dependencies (--refresh-dependencies) -- run after
+--            adding/removing a dependency so jdtls picks it up
+-- The command runs as a background job; a spinner takes over the statusline
+-- while it runs, then shows OK/FAILED for a few seconds. On failure the output
+-- goes to the quickfix list (:copen). On SUCCESS the jdtls workspace cache is
+-- wiped and loaded, unmodified Java buffers are reloaded so jdtls re-imports
+-- with the fresh classpath.
 local M = {}
 
--- Gradle task for "build"; tests are skipped (-x test) in build_cmd below. Swap
--- to "assemble" or "compileJava" for an even lighter compile-only build.
+-- SPC j b task; tests are skipped via -x test in build_cmd. Use "assemble" or
+-- "compileJava" for an even lighter compile-only build.
 local GRADLE_TASK = "build"
 
 local spinner = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
@@ -23,33 +29,8 @@ local function restore()
   vim.cmd("redrawstatus")
 end
 
--- Pick a build command from the tooling present at the project root. The
--- wrappers are passed as ABSOLUTE paths: jobstart's "is the command executable"
--- check runs against Neovim's cwd, not the job's cwd, so a relative "./gradlew"
--- errors (E475) whenever nvim isn't sitting in the Gradle root.
-local function build_cmd(root)
-  local has = function(p)
-    return vim.uv.fs_stat(root .. "/" .. p) ~= nil
-  end
-  if has("gradlew") then
-    return { root .. "/gradlew", GRADLE_TASK, "-x", "test" }, "gradle"
-  elseif has("mvnw") then
-    return { root .. "/mvnw", "compile" }, "maven"
-  elseif has("pom.xml") then
-    return { "mvn", "compile" }, "maven"
-  elseif has("package.json") then
-    return { "npm", "run", "build" }, "npm"
-  end
-  return nil
-end
-
-function M.build()
-  if state.running then
-    vim.notify("Build already running", vim.log.levels.WARN)
-    return
-  end
-
-  local root = vim.fs.root(0, {
+local function project_root()
+  return vim.fs.root(0, {
     "settings.gradle",
     "settings.gradle.kts",
     "gradlew",
@@ -58,13 +39,41 @@ function M.build()
     "package.json",
     ".git",
   }) or vim.fn.getcwd()
+end
 
-  local cmd, tool = build_cmd(root)
-  if not cmd then
-    vim.notify("No gradle/maven/npm build tool found at " .. root, vim.log.levels.ERROR)
+-- Wipe the jdtls workspace cache and restart jdtls on open Java buffers so it
+-- re-imports with the current classpath (e.g. a newly added dependency).
+-- Unmodified buffers only, so no unsaved work is lost.
+local function refresh_jdtls()
+  for _, c in ipairs(vim.lsp.get_clients({ name = "jdtls" })) do
+    vim.lsp.stop_client(c.id, true)
+  end
+  vim.fn.delete(vim.fn.stdpath("cache") .. "/jdtls", "rf")
+  vim.defer_fn(function()
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if
+        vim.api.nvim_buf_is_loaded(buf)
+        and vim.bo[buf].filetype == "java"
+        and not vim.bo[buf].modified
+        and vim.api.nvim_buf_get_name(buf) ~= ""
+      then
+        vim.api.nvim_buf_call(buf, function()
+          vim.cmd("edit")
+        end)
+      end
+    end
+    vim.notify("jdtls cache cleared — re-importing project", vim.log.levels.INFO)
+  end, 300)
+end
+
+-- Run an async job from the project root: spinner on the statusline, quickfix on
+-- failure, jdtls refresh on success. The wrappers are absolute paths because
+-- jobstart's executable check runs against Neovim's cwd, not the job's cwd.
+local function run(root, cmd, tool, verb)
+  if state.running then
+    vim.notify("A build/refresh is already running", vim.log.levels.WARN)
     return
   end
-
   state.running = true
   state.saved = vim.o.statusline
   state.frame = 1
@@ -73,7 +82,7 @@ function M.build()
 
   state.timer = vim.fn.timer_start(100, function()
     state.frame = state.frame % #spinner + 1
-    show(spinner[state.frame] .. "  Building " .. name .. " (" .. tool .. ")…")
+    show(spinner[state.frame] .. "  " .. verb .. " " .. name .. " (" .. tool .. ")…")
   end, { ["repeat"] = -1 })
 
   vim.fn.jobstart(cmd, {
@@ -97,14 +106,53 @@ function M.build()
         state.timer = nil
       end
       if code == 0 then
-        show("✓  Build OK — " .. name)
+        show("✓  " .. verb .. " OK — " .. name .. "; refreshing jdtls…")
+        refresh_jdtls()
       else
-        show("✗  Build FAILED (exit " .. code .. ") — :copen for errors")
-        vim.fn.setqflist({}, "r", { title = "Build " .. name, lines = out })
+        show("✗  " .. verb .. " FAILED (exit " .. code .. ") — :copen for errors")
+        vim.fn.setqflist({}, "r", { title = verb .. " " .. name, lines = out })
       end
       vim.defer_fn(restore, 4000)
     end,
   })
+end
+
+-- gradle/maven/npm wrapper for the build task.
+local function build_cmd(root)
+  local has = function(p)
+    return vim.uv.fs_stat(root .. "/" .. p) ~= nil
+  end
+  if has("gradlew") then
+    return { root .. "/gradlew", GRADLE_TASK, "-x", "test" }, "gradle"
+  elseif has("mvnw") then
+    return { root .. "/mvnw", "compile" }, "maven"
+  elseif has("pom.xml") then
+    return { "mvn", "compile" }, "maven"
+  elseif has("package.json") then
+    return { "npm", "run", "build" }, "npm"
+  end
+  return nil
+end
+
+function M.build()
+  local root = project_root()
+  local cmd, tool = build_cmd(root)
+  if not cmd then
+    vim.notify("No gradle/maven/npm build tool found at " .. root, vim.log.levels.ERROR)
+    return
+  end
+  run(root, cmd, tool, "Building")
+end
+
+-- Force Gradle to re-resolve dependencies (after adding/removing one), then
+-- refresh jdtls so the new deps land on its classpath.
+function M.refresh_deps()
+  local root = project_root()
+  if not vim.uv.fs_stat(root .. "/gradlew") then
+    vim.notify("No gradlew at " .. root .. " (refresh-dependencies is Gradle-only)", vim.log.levels.ERROR)
+    return
+  end
+  run(root, { root .. "/gradlew", "dependencies", "--refresh-dependencies" }, "gradle", "Refreshing deps")
 end
 
 return M

--- a/linux/.config/nvim/lua/config/keymaps.lua
+++ b/linux/.config/nvim/lua/config/keymaps.lua
@@ -51,10 +51,13 @@ map("n", "<leader>bb", "<cmd>e #<CR>", { desc = "Switch to other buffer" })
 map("n", "<leader>fs", "<cmd>w<CR>", { desc = "Save file" })
 map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })
 
--- SPC c — code (LSP maps bind per-buffer in plugins/lsp.lua; build is global)
-map("n", "<leader>cb", function()
+-- SPC j — java: build / Gradle, each refreshes the jdtls cache on success
+map("n", "<leader>jb", function()
   require("config.build").build()
 end, { desc = "Build project" })
+map("n", "<leader>jd", function()
+  require("config.build").refresh_deps()
+end, { desc = "Refresh Gradle dependencies" })
 
 -- SPC p — project (group also populated in plugins/project.lua)
 map("n", "<leader>ps", "<cmd>wa<CR>", { desc = "Save all project files" })

--- a/linux/.config/nvim/lua/plugins/which-key.lua
+++ b/linux/.config/nvim/lua/plugins/which-key.lua
@@ -9,6 +9,7 @@ return {
       { "<leader>c", group = "code" },
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
+      { "<leader>j", group = "java" },
       { "<leader>m", group = "markdown" },
       { "<leader>o", group = "open" },
       { "<leader>p", group = "project" },

--- a/macbook/.config/nvim/lua/config/build.lua
+++ b/macbook/.config/nvim/lua/config/build.lua
@@ -1,12 +1,18 @@
--- Async project build with a statusline progress indicator. SPC c b (mapped in
--- config/keymaps.lua) runs the project's build tool -- gradle / maven / npm,
--- auto-detected from the root -- as a background job. A spinner takes over the
--- statusline while it runs, then shows OK / FAILED for a few seconds. On failure
--- the captured output goes to the quickfix list (:copen) so errors are navigable.
+-- Async Gradle/Maven/npm actions with a statusline progress indicator, plus a
+-- jdtls cache refresh so the Java LSP re-imports afterwards. Bound in
+-- config/keymaps.lua under SPC j (java):
+--   SPC j b  build the project (gradle: build -x test)
+--   SPC j d  refresh Gradle dependencies (--refresh-dependencies) -- run after
+--            adding/removing a dependency so jdtls picks it up
+-- The command runs as a background job; a spinner takes over the statusline
+-- while it runs, then shows OK/FAILED for a few seconds. On failure the output
+-- goes to the quickfix list (:copen). On SUCCESS the jdtls workspace cache is
+-- wiped and loaded, unmodified Java buffers are reloaded so jdtls re-imports
+-- with the fresh classpath.
 local M = {}
 
--- Gradle task for "build"; tests are skipped (-x test) in build_cmd below. Swap
--- to "assemble" or "compileJava" for an even lighter compile-only build.
+-- SPC j b task; tests are skipped via -x test in build_cmd. Use "assemble" or
+-- "compileJava" for an even lighter compile-only build.
 local GRADLE_TASK = "build"
 
 local spinner = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
@@ -23,33 +29,8 @@ local function restore()
   vim.cmd("redrawstatus")
 end
 
--- Pick a build command from the tooling present at the project root. The
--- wrappers are passed as ABSOLUTE paths: jobstart's "is the command executable"
--- check runs against Neovim's cwd, not the job's cwd, so a relative "./gradlew"
--- errors (E475) whenever nvim isn't sitting in the Gradle root.
-local function build_cmd(root)
-  local has = function(p)
-    return vim.uv.fs_stat(root .. "/" .. p) ~= nil
-  end
-  if has("gradlew") then
-    return { root .. "/gradlew", GRADLE_TASK, "-x", "test" }, "gradle"
-  elseif has("mvnw") then
-    return { root .. "/mvnw", "compile" }, "maven"
-  elseif has("pom.xml") then
-    return { "mvn", "compile" }, "maven"
-  elseif has("package.json") then
-    return { "npm", "run", "build" }, "npm"
-  end
-  return nil
-end
-
-function M.build()
-  if state.running then
-    vim.notify("Build already running", vim.log.levels.WARN)
-    return
-  end
-
-  local root = vim.fs.root(0, {
+local function project_root()
+  return vim.fs.root(0, {
     "settings.gradle",
     "settings.gradle.kts",
     "gradlew",
@@ -58,13 +39,41 @@ function M.build()
     "package.json",
     ".git",
   }) or vim.fn.getcwd()
+end
 
-  local cmd, tool = build_cmd(root)
-  if not cmd then
-    vim.notify("No gradle/maven/npm build tool found at " .. root, vim.log.levels.ERROR)
+-- Wipe the jdtls workspace cache and restart jdtls on open Java buffers so it
+-- re-imports with the current classpath (e.g. a newly added dependency).
+-- Unmodified buffers only, so no unsaved work is lost.
+local function refresh_jdtls()
+  for _, c in ipairs(vim.lsp.get_clients({ name = "jdtls" })) do
+    vim.lsp.stop_client(c.id, true)
+  end
+  vim.fn.delete(vim.fn.stdpath("cache") .. "/jdtls", "rf")
+  vim.defer_fn(function()
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if
+        vim.api.nvim_buf_is_loaded(buf)
+        and vim.bo[buf].filetype == "java"
+        and not vim.bo[buf].modified
+        and vim.api.nvim_buf_get_name(buf) ~= ""
+      then
+        vim.api.nvim_buf_call(buf, function()
+          vim.cmd("edit")
+        end)
+      end
+    end
+    vim.notify("jdtls cache cleared — re-importing project", vim.log.levels.INFO)
+  end, 300)
+end
+
+-- Run an async job from the project root: spinner on the statusline, quickfix on
+-- failure, jdtls refresh on success. The wrappers are absolute paths because
+-- jobstart's executable check runs against Neovim's cwd, not the job's cwd.
+local function run(root, cmd, tool, verb)
+  if state.running then
+    vim.notify("A build/refresh is already running", vim.log.levels.WARN)
     return
   end
-
   state.running = true
   state.saved = vim.o.statusline
   state.frame = 1
@@ -73,7 +82,7 @@ function M.build()
 
   state.timer = vim.fn.timer_start(100, function()
     state.frame = state.frame % #spinner + 1
-    show(spinner[state.frame] .. "  Building " .. name .. " (" .. tool .. ")…")
+    show(spinner[state.frame] .. "  " .. verb .. " " .. name .. " (" .. tool .. ")…")
   end, { ["repeat"] = -1 })
 
   vim.fn.jobstart(cmd, {
@@ -97,14 +106,53 @@ function M.build()
         state.timer = nil
       end
       if code == 0 then
-        show("✓  Build OK — " .. name)
+        show("✓  " .. verb .. " OK — " .. name .. "; refreshing jdtls…")
+        refresh_jdtls()
       else
-        show("✗  Build FAILED (exit " .. code .. ") — :copen for errors")
-        vim.fn.setqflist({}, "r", { title = "Build " .. name, lines = out })
+        show("✗  " .. verb .. " FAILED (exit " .. code .. ") — :copen for errors")
+        vim.fn.setqflist({}, "r", { title = verb .. " " .. name, lines = out })
       end
       vim.defer_fn(restore, 4000)
     end,
   })
+end
+
+-- gradle/maven/npm wrapper for the build task.
+local function build_cmd(root)
+  local has = function(p)
+    return vim.uv.fs_stat(root .. "/" .. p) ~= nil
+  end
+  if has("gradlew") then
+    return { root .. "/gradlew", GRADLE_TASK, "-x", "test" }, "gradle"
+  elseif has("mvnw") then
+    return { root .. "/mvnw", "compile" }, "maven"
+  elseif has("pom.xml") then
+    return { "mvn", "compile" }, "maven"
+  elseif has("package.json") then
+    return { "npm", "run", "build" }, "npm"
+  end
+  return nil
+end
+
+function M.build()
+  local root = project_root()
+  local cmd, tool = build_cmd(root)
+  if not cmd then
+    vim.notify("No gradle/maven/npm build tool found at " .. root, vim.log.levels.ERROR)
+    return
+  end
+  run(root, cmd, tool, "Building")
+end
+
+-- Force Gradle to re-resolve dependencies (after adding/removing one), then
+-- refresh jdtls so the new deps land on its classpath.
+function M.refresh_deps()
+  local root = project_root()
+  if not vim.uv.fs_stat(root .. "/gradlew") then
+    vim.notify("No gradlew at " .. root .. " (refresh-dependencies is Gradle-only)", vim.log.levels.ERROR)
+    return
+  end
+  run(root, { root .. "/gradlew", "dependencies", "--refresh-dependencies" }, "gradle", "Refreshing deps")
 end
 
 return M

--- a/macbook/.config/nvim/lua/config/keymaps.lua
+++ b/macbook/.config/nvim/lua/config/keymaps.lua
@@ -51,10 +51,13 @@ map("n", "<leader>bb", "<cmd>e #<CR>", { desc = "Switch to other buffer" })
 map("n", "<leader>fs", "<cmd>w<CR>", { desc = "Save file" })
 map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })
 
--- SPC c — code (LSP maps bind per-buffer in plugins/lsp.lua; build is global)
-map("n", "<leader>cb", function()
+-- SPC j — java: build / Gradle, each refreshes the jdtls cache on success
+map("n", "<leader>jb", function()
   require("config.build").build()
 end, { desc = "Build project" })
+map("n", "<leader>jd", function()
+  require("config.build").refresh_deps()
+end, { desc = "Refresh Gradle dependencies" })
 
 -- SPC p — project (group also populated in plugins/project.lua)
 map("n", "<leader>ps", "<cmd>wa<CR>", { desc = "Save all project files" })

--- a/macbook/.config/nvim/lua/plugins/which-key.lua
+++ b/macbook/.config/nvim/lua/plugins/which-key.lua
@@ -9,6 +9,7 @@ return {
       { "<leader>c", group = "code" },
       { "<leader>f", group = "file" },
       { "<leader>g", group = "git" },
+      { "<leader>j", group = "java" },
       { "<leader>m", group = "markdown" },
       { "<leader>o", group = "open" },
       { "<leader>p", group = "project" },


### PR DESCRIPTION
## what

new **SPC j** (java) group:
- **SPC j b** — build project (was SPC c b). gradle `build -x test`.
- **SPC j d** — gradle **refresh dependencies** (`dependencies --refresh-dependencies`). run after add/remove a dep.

both:
- run **async** with the statusline **spinner** (OK/FAILED after, quickfix on fail).
- on **success**, **wipe the jdtls workspace cache** and reload open (unmodified) java buffers so jdtls **re-import with the fresh classpath**.

this is the fix for "added quarkus-scheduler but `@Scheduled` no complete": after SPC j d, jdtls re-import and see the new dep.

## files

- `config/build.lua` (mac + linux) — add refresh_deps + refresh_jdtls, SPC j b/d
- `config/keymaps.lua` (mac + linux) — SPC c b -> SPC j b, add SPC j d
- `which-key.lua` (mac + linux) — new "java" group

## note

- jdtls refresh happen on **success only** (re-import a failed build is pointless).
- unmodified java buffers reload to restart jdtls; modified buffers skip (save first).
- still need gradle build to actually work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)