### PR TITLE
fix(nvim): enter accepts completion on the same line

### DIFF
--- a/linux/.config/nvim/lua/plugins/blink.lua
+++ b/linux/.config/nvim/lua/plugins/blink.lua
@@ -9,7 +9,7 @@ return {
     keymap = {
       preset = "default", -- <C-space> shows menu/docs; <C-n>/<C-p> navigate
       ["<Tab>"] = { "accept", "fallback" }, -- Tab applies the selection
-      ["<CR>"] = { "fallback" }, -- Enter never accepts: closes menu + new line
+      ["<CR>"] = { "accept", "fallback" }, -- Enter accepts on the same line when the menu is open, else newline
     },
     sources = {
       default = { "lsp", "path", "snippets", "buffer" },

--- a/macbook/.config/nvim/lua/plugins/blink.lua
+++ b/macbook/.config/nvim/lua/plugins/blink.lua
@@ -9,7 +9,7 @@ return {
     keymap = {
       preset = "default", -- <C-space> shows menu/docs; <C-n>/<C-p> navigate
       ["<Tab>"] = { "accept", "fallback" }, -- Tab applies the selection
-      ["<CR>"] = { "fallback" }, -- Enter never accepts: closes menu + new line
+      ["<CR>"] = { "accept", "fallback" }, -- Enter accepts on the same line when the menu is open, else newline
     },
     sources = {
       default = { "lsp", "path", "snippets", "buffer" },


### PR DESCRIPTION
## what

accepting a completion with **Enter** was breaking the line: `<CR>` was `{ "fallback" }` (newline only), so enter never accepted -- it just made a new line.

now `<CR>` = `{ "accept", "fallback" }`:
- **menu open** -> enter **accepts** the selection, cursor stay on the **same line**.
- **menu closed** -> enter make a newline like normal.

tab still accepts too.

## file

- `blink.lua` (mac + linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)