### PR TITLE
feat(nvim): auto-close brackets (nvim-autopairs)

### DIFF
--- a/linux/.config/nvim/lua/plugins/autopairs.lua
+++ b/linux/.config/nvim/lua/plugins/autopairs.lua
@@ -1,0 +1,11 @@
+-- Auto-close pairs: typing ( [ { " ' ` inserts the matching close, skips over an
+-- existing close instead of doubling it, and deletes both halves on backspace.
+-- check_ts uses treesitter (see treesitter.lua) to avoid pairing inside strings
+-- and comments.
+return {
+  "windwp/nvim-autopairs",
+  event = "InsertEnter",
+  opts = {
+    check_ts = true,
+  },
+}

--- a/macbook/.config/nvim/lua/plugins/autopairs.lua
+++ b/macbook/.config/nvim/lua/plugins/autopairs.lua
@@ -1,0 +1,11 @@
+-- Auto-close pairs: typing ( [ { " ' ` inserts the matching close, skips over an
+-- existing close instead of doubling it, and deletes both halves on backspace.
+-- check_ts uses treesitter (see treesitter.lua) to avoid pairing inside strings
+-- and comments.
+return {
+  "windwp/nvim-autopairs",
+  event = "InsertEnter",
+  opts = {
+    check_ts = true,
+  },
+}


### PR DESCRIPTION
## what

type an opening `(` `[` `{` `"` `'` and the closing one insert itself.

- add **nvim-autopairs**, load on InsertEnter.
- skip over an existing close instead of doubling; backspace delete both halves.
- **check_ts** = use treesitter so it no add a pair inside string / comment.

## file

- `autopairs.lua` (new, mac + linux)

restart nvim -> lazy install it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)