### PR TITLE
fix(nvim): jdtls refresh updates all modules without prompting

### DIFF
--- a/linux/.config/nvim/lua/config/build.lua
+++ b/linux/.config/nvim/lua/config/build.lua
@@ -50,7 +50,8 @@ local function refresh_jdtls()
   end
   local ok, jdtls = pcall(require, "jdtls")
   if ok then
-    pcall(jdtls.update_projects_config)
+    -- select_mode = "all" updates every module without the "which project?" prompt
+    pcall(jdtls.update_projects_config, { select_mode = "all" })
     vim.notify("jdtls project config updated", vim.log.levels.INFO)
   end
 end

--- a/macbook/.config/nvim/lua/config/build.lua
+++ b/macbook/.config/nvim/lua/config/build.lua
@@ -50,7 +50,8 @@ local function refresh_jdtls()
   end
   local ok, jdtls = pcall(require, "jdtls")
   if ok then
-    pcall(jdtls.update_projects_config)
+    -- select_mode = "all" updates every module without the "which project?" prompt
+    pcall(jdtls.update_projects_config, { select_mode = "all" })
     vim.notify("jdtls project config updated", vim.log.levels.INFO)
   end
 end


### PR DESCRIPTION
## what

on a multi-module project, `SPC j b`/`SPC j d` jdtls refresh was prompting **"which project to update?"**.

pass **`select_mode = "all"`** to `update_projects_config` so it update every module without asking.

## file

- `config/build.lua` (mac + linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)