### PR TITLE
feat(nvim): code actions select with arrows (telescope-ui-select)

### DIFF
--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -25,7 +25,10 @@ end
 return {
   "nvim-telescope/telescope.nvim",
   branch = "0.1.x",
-  dependencies = { "nvim-lua/plenary.nvim" },
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-telescope/telescope-ui-select.nvim", -- vim.ui.select (code actions) via telescope
+  },
   cmd = "Telescope",
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
@@ -49,4 +52,14 @@ return {
       },
     },
   },
+  -- Route vim.ui.select (used by LSP code actions) through a Telescope dropdown,
+  -- so it is navigable with the arrow keys instead of typed numbers.
+  config = function(_, opts)
+    opts.extensions = {
+      ["ui-select"] = { require("telescope.themes").get_dropdown() },
+    }
+    local telescope = require("telescope")
+    telescope.setup(opts)
+    telescope.load_extension("ui_select")
+  end,
 }

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -25,7 +25,10 @@ end
 return {
   "nvim-telescope/telescope.nvim",
   branch = "0.1.x",
-  dependencies = { "nvim-lua/plenary.nvim" },
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-telescope/telescope-ui-select.nvim", -- vim.ui.select (code actions) via telescope
+  },
   cmd = "Telescope",
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
@@ -49,4 +52,14 @@ return {
       },
     },
   },
+  -- Route vim.ui.select (used by LSP code actions) through a Telescope dropdown,
+  -- so it is navigable with the arrow keys instead of typed numbers.
+  config = function(_, opts)
+    opts.extensions = {
+      ["ui-select"] = { require("telescope.themes").get_dropdown() },
+    }
+    local telescope = require("telescope")
+    telescope.setup(opts)
+    telescope.load_extension("ui_select")
+  end,
 }


### PR DESCRIPTION
## what

LSP code actions (SPC c a) use `vim.ui.select`, which by default show a numbered command-line list you pick by number.

add **telescope-ui-select**: route `vim.ui.select` through a telescope dropdown, so code actions (and any other select) navigate with **up/down arrows** (C-n/C-p too) and filter by typing.

## files

- `telescope.lua` (mac + linux) — add `telescope-ui-select.nvim` dep, load the `ui_select` extension in a config fn (dropdown theme)

restart nvim -> lazy install the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)