### PR TITLE
fix(nvim): guard ui_select load so it can't break telescope

### DIFF
--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -60,6 +60,10 @@ return {
     }
     local telescope = require("telescope")
     telescope.setup(opts)
-    telescope.load_extension("ui_select")
+    -- Guard: a not-yet-installed extension (e.g. on a fresh machine before
+    -- :Lazy sync) must not break all of telescope. Warn instead of erroring.
+    if not pcall(telescope.load_extension, "ui_select") then
+      vim.notify("telescope ui-select not installed yet — run :Lazy sync", vim.log.levels.WARN)
+    end
   end,
 }

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -60,6 +60,10 @@ return {
     }
     local telescope = require("telescope")
     telescope.setup(opts)
-    telescope.load_extension("ui_select")
+    -- Guard: a not-yet-installed extension (e.g. on a fresh machine before
+    -- :Lazy sync) must not break all of telescope. Warn instead of erroring.
+    if not pcall(telescope.load_extension, "ui_select") then
+      vim.notify("telescope ui-select not installed yet — run :Lazy sync", vim.log.levels.WARN)
+    end
   end,
 }


### PR DESCRIPTION
## what

`telescope-ui-select` not installed yet (fresh machine before `:Lazy sync`) -> `load_extension("ui_select")` throw **inside telescope config**, breaking **all of telescope** at startup (find_files, live_grep, etc.), since telescope load eager via project.nvim/neogit.

wrap the load in **pcall** + a warn notify. telescope keep working; once the extension install and you restart, arrows work.

## fix on your machine now

`:Lazy sync` then restart -> installs the extension, error gone.

## file

- `telescope.lua` (mac + linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)