### PR TITLE
feat(nvim): SPC c r rename symbol

### DIFF
--- a/linux/.config/nvim/lua/plugins/lsp.lua
+++ b/linux/.config/nvim/lua/plugins/lsp.lua
@@ -43,6 +43,7 @@ return {
           m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
           m("<leader>cD", "<cmd>Telescope lsp_references<CR>", "Find usages")
           m("<leader>ca", vim.lsp.buf.code_action, "Code action")
+          m("<leader>cr", vim.lsp.buf.rename, "Rename symbol")
           -- SPC c f (format) is a global keymap in conform.lua so it works even
           -- without an LSP attached.
         end,

--- a/macbook/.config/nvim/lua/plugins/lsp.lua
+++ b/macbook/.config/nvim/lua/plugins/lsp.lua
@@ -43,6 +43,7 @@ return {
           m("<leader>cd", vim.lsp.buf.definition, "Go to definition")
           m("<leader>cD", "<cmd>Telescope lsp_references<CR>", "Find usages")
           m("<leader>ca", vim.lsp.buf.code_action, "Code action")
+          m("<leader>cr", vim.lsp.buf.rename, "Rename symbol")
           -- SPC c f (format) is a global keymap in conform.lua so it works even
           -- without an LSP attached.
         end,


### PR DESCRIPTION
## what

**SPC c r** rename the symbol under cursor via `vim.lsp.buf.rename` (LSP rename across the project).

join the code group next to `cd` (definition), `cD` (usages), `ca` (code action). bind per-buffer on LspAttach.

mac + linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)