### PR TITLE
fix(nvim): code actions use telescope even before it loads

### DIFF
--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -30,6 +30,21 @@ return {
     "nvim-telescope/telescope-ui-select.nvim", -- vim.ui.select (code actions) via telescope
   },
   cmd = "Telescope",
+  -- Route vim.ui.select (LSP code actions) through telescope even though
+  -- telescope is lazy-loaded. This shim runs at startup; the first select loads
+  -- telescope, whose config replaces vim.ui.select with the picker, then we
+  -- delegate to it. Until telescope loads (or if it fails) we fall back to the
+  -- builtin, so code actions never depend on having opened telescope first.
+  init = function()
+    local builtin = vim.ui.select
+    local shim
+    shim = function(items, opts, on_choice)
+      pcall(require, "telescope") -- loads telescope; its config sets vim.ui.select
+      local impl = vim.ui.select ~= shim and vim.ui.select or builtin
+      return impl(items, opts, on_choice)
+    end
+    vim.ui.select = shim
+  end,
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
     { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -30,6 +30,21 @@ return {
     "nvim-telescope/telescope-ui-select.nvim", -- vim.ui.select (code actions) via telescope
   },
   cmd = "Telescope",
+  -- Route vim.ui.select (LSP code actions) through telescope even though
+  -- telescope is lazy-loaded. This shim runs at startup; the first select loads
+  -- telescope, whose config replaces vim.ui.select with the picker, then we
+  -- delegate to it. Until telescope loads (or if it fails) we fall back to the
+  -- builtin, so code actions never depend on having opened telescope first.
+  init = function()
+    local builtin = vim.ui.select
+    local shim
+    shim = function(items, opts, on_choice)
+      pcall(require, "telescope") -- loads telescope; its config sets vim.ui.select
+      local impl = vim.ui.select ~= shim and vim.ui.select or builtin
+      return impl(items, opts, on_choice)
+    end
+    vim.ui.select = shim
+  end,
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
     { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },


### PR DESCRIPTION
## what

code actions sometimes open the **numbered** menu instead of telescope.

cause: telescope is **lazy-loaded** (cmd/keys). its `config` -- which call `load_extension("ui_select")` and replace `vim.ui.select` -- only run after the **first Telescope command**. a code action triggered before that use the default `vim.ui.select`. (that is why running `require("telescope")` in the diag "fixed" it.)

fix: add a startup **`init`** shim that set `vim.ui.select` to a wrapper. first call it `require("telescope")` (load it, its config set vim.ui.select to the picker), then delegate. builtin fallback if telescope not loaded / extension missing, so no recursion.

## file

- `telescope.lua` (mac + linux)

now code actions open in telescope from the first use, no need to open telescope first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)