### PR TITLE
fix(nvim): dressing.nvim for arrow-navigable code actions

### DIFF
--- a/linux/.config/nvim/lua/plugins/dressing.lua
+++ b/linux/.config/nvim/lua/plugins/dressing.lua
@@ -1,0 +1,15 @@
+-- dressing.nvim overrides vim.ui.select and vim.ui.input, so LSP code actions
+-- (SPC c a) and other menus are navigable with the arrow keys instead of the
+-- default numbered command-line prompt. Select prefers a telescope picker
+-- (consistent with the other finders) and falls back to a builtin floating
+-- menu. Unlike telescope-ui-select, dressing patches vim.ui directly, which
+-- takes reliably in this setup.
+return {
+  "stevearc/dressing.nvim",
+  event = "VeryLazy",
+  opts = {
+    select = {
+      backend = { "telescope", "builtin" },
+    },
+  },
+}

--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -25,26 +25,8 @@ end
 return {
   "nvim-telescope/telescope.nvim",
   branch = "0.1.x",
-  dependencies = {
-    "nvim-lua/plenary.nvim",
-    "nvim-telescope/telescope-ui-select.nvim", -- vim.ui.select (code actions) via telescope
-  },
+  dependencies = { "nvim-lua/plenary.nvim" },
   cmd = "Telescope",
-  -- Route vim.ui.select (LSP code actions) through telescope even though
-  -- telescope is lazy-loaded. This shim runs at startup; the first select loads
-  -- telescope, whose config replaces vim.ui.select with the picker, then we
-  -- delegate to it. Until telescope loads (or if it fails) we fall back to the
-  -- builtin, so code actions never depend on having opened telescope first.
-  init = function()
-    local builtin = vim.ui.select
-    local shim
-    shim = function(items, opts, on_choice)
-      pcall(require, "telescope") -- loads telescope; its config sets vim.ui.select
-      local impl = vim.ui.select ~= shim and vim.ui.select or builtin
-      return impl(items, opts, on_choice)
-    end
-    vim.ui.select = shim
-  end,
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
     { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },
@@ -67,18 +49,4 @@ return {
       },
     },
   },
-  -- Route vim.ui.select (used by LSP code actions) through a Telescope dropdown,
-  -- so it is navigable with the arrow keys instead of typed numbers.
-  config = function(_, opts)
-    opts.extensions = {
-      ["ui-select"] = { require("telescope.themes").get_dropdown() },
-    }
-    local telescope = require("telescope")
-    telescope.setup(opts)
-    -- Guard: a not-yet-installed extension (e.g. on a fresh machine before
-    -- :Lazy sync) must not break all of telescope. Warn instead of erroring.
-    if not pcall(telescope.load_extension, "ui_select") then
-      vim.notify("telescope ui-select not installed yet — run :Lazy sync", vim.log.levels.WARN)
-    end
-  end,
 }

--- a/macbook/.config/nvim/lua/plugins/dressing.lua
+++ b/macbook/.config/nvim/lua/plugins/dressing.lua
@@ -1,0 +1,15 @@
+-- dressing.nvim overrides vim.ui.select and vim.ui.input, so LSP code actions
+-- (SPC c a) and other menus are navigable with the arrow keys instead of the
+-- default numbered command-line prompt. Select prefers a telescope picker
+-- (consistent with the other finders) and falls back to a builtin floating
+-- menu. Unlike telescope-ui-select, dressing patches vim.ui directly, which
+-- takes reliably in this setup.
+return {
+  "stevearc/dressing.nvim",
+  event = "VeryLazy",
+  opts = {
+    select = {
+      backend = { "telescope", "builtin" },
+    },
+  },
+}

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -25,26 +25,8 @@ end
 return {
   "nvim-telescope/telescope.nvim",
   branch = "0.1.x",
-  dependencies = {
-    "nvim-lua/plenary.nvim",
-    "nvim-telescope/telescope-ui-select.nvim", -- vim.ui.select (code actions) via telescope
-  },
+  dependencies = { "nvim-lua/plenary.nvim" },
   cmd = "Telescope",
-  -- Route vim.ui.select (LSP code actions) through telescope even though
-  -- telescope is lazy-loaded. This shim runs at startup; the first select loads
-  -- telescope, whose config replaces vim.ui.select with the picker, then we
-  -- delegate to it. Until telescope loads (or if it fails) we fall back to the
-  -- builtin, so code actions never depend on having opened telescope first.
-  init = function()
-    local builtin = vim.ui.select
-    local shim
-    shim = function(items, opts, on_choice)
-      pcall(require, "telescope") -- loads telescope; its config sets vim.ui.select
-      local impl = vim.ui.select ~= shim and vim.ui.select or builtin
-      return impl(items, opts, on_choice)
-    end
-    vim.ui.select = shim
-  end,
   keys = {
     { "<leader><leader>", "<cmd>Telescope find_files<CR>", desc = "Find files" },
     { "<leader>fr", "<cmd>Telescope oldfiles<CR>", desc = "Recent files" },
@@ -67,18 +49,4 @@ return {
       },
     },
   },
-  -- Route vim.ui.select (used by LSP code actions) through a Telescope dropdown,
-  -- so it is navigable with the arrow keys instead of typed numbers.
-  config = function(_, opts)
-    opts.extensions = {
-      ["ui-select"] = { require("telescope.themes").get_dropdown() },
-    }
-    local telescope = require("telescope")
-    telescope.setup(opts)
-    -- Guard: a not-yet-installed extension (e.g. on a fresh machine before
-    -- :Lazy sync) must not break all of telescope. Warn instead of erroring.
-    if not pcall(telescope.load_extension, "ui_select") then
-      vim.notify("telescope ui-select not installed yet — run :Lazy sync", vim.log.levels.WARN)
-    end
-  end,
 }


### PR DESCRIPTION
## what

code actions kept opening the **numbered** menu. diagnosed: **telescope-ui-select never patched `vim.ui.select`** in this setup -- a manual `vim.ui.select(...)` showed the numbered prompt even after telescope + the extension were loaded. so the timing fixes couldn't help; the override itself wasn't taking.

swap to **dressing.nvim**, which patches `vim.ui.select` / `vim.ui.input` directly:
- revert `telescope.lua` to plain config (remove ui-select dependency, init shim, config fn).
- add `dressing.lua`. select backend = **telescope** with a **builtin** floating-menu fallback -> code actions (and any menu) navigate with **up/down arrows**.

## files

- `telescope.lua` (mac + linux) — revert ui-select wiring
- `dressing.lua` (new, mac + linux)

restart nvim after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)