### PR TITLE
feat(nvim): assertj in jdtls favorite static members

### DIFF
--- a/linux/.config/nvim/lua/plugins/jdtls.lua
+++ b/linux/.config/nvim/lua/plugins/jdtls.lua
@@ -112,6 +112,29 @@ local nvim_jdtls = {
         root_dir = root,
         capabilities = require("blink.cmp").get_lsp_capabilities(),
         init_options = { extendedClientCapabilities = caps },
+        settings = {
+          java = {
+            completion = {
+              -- jdtls only completes/auto-imports static members from this list.
+              -- It defaults to JUnit + Mockito; add AssertJ (and keep the
+              -- defaults) so assertThat / assertThatThrownBy resolve and import.
+              favoriteStaticMembers = {
+                "org.assertj.core.api.Assertions.*",
+                "org.assertj.core.api.Assumptions.*",
+                "org.assertj.core.api.InstanceOfAssertFactories.*",
+                "org.junit.jupiter.api.Assertions.*",
+                "org.junit.jupiter.api.Assumptions.*",
+                "org.junit.jupiter.api.DynamicTest.*",
+                "org.junit.jupiter.api.DynamicContainer.*",
+                "org.junit.Assert.*",
+                "org.junit.Assume.*",
+                "org.mockito.Mockito.*",
+                "org.mockito.ArgumentMatchers.*",
+                "org.mockito.Answers.*",
+              },
+            },
+          },
+        },
         on_attach = function(_, bufnr)
           -- generic SPC c d/D/a/f come from lsp.lua's LspAttach; add the
           -- jdtls-only organize-imports here.

--- a/macbook/.config/nvim/lua/plugins/jdtls.lua
+++ b/macbook/.config/nvim/lua/plugins/jdtls.lua
@@ -112,6 +112,29 @@ local nvim_jdtls = {
         root_dir = root,
         capabilities = require("blink.cmp").get_lsp_capabilities(),
         init_options = { extendedClientCapabilities = caps },
+        settings = {
+          java = {
+            completion = {
+              -- jdtls only completes/auto-imports static members from this list.
+              -- It defaults to JUnit + Mockito; add AssertJ (and keep the
+              -- defaults) so assertThat / assertThatThrownBy resolve and import.
+              favoriteStaticMembers = {
+                "org.assertj.core.api.Assertions.*",
+                "org.assertj.core.api.Assumptions.*",
+                "org.assertj.core.api.InstanceOfAssertFactories.*",
+                "org.junit.jupiter.api.Assertions.*",
+                "org.junit.jupiter.api.Assumptions.*",
+                "org.junit.jupiter.api.DynamicTest.*",
+                "org.junit.jupiter.api.DynamicContainer.*",
+                "org.junit.Assert.*",
+                "org.junit.Assume.*",
+                "org.mockito.Mockito.*",
+                "org.mockito.ArgumentMatchers.*",
+                "org.mockito.Answers.*",
+              },
+            },
+          },
+        },
         on_attach = function(_, bufnr)
           -- generic SPC c d/D/a/f come from lsp.lua's LspAttach; add the
           -- jdtls-only organize-imports here.


### PR DESCRIPTION
## what

jdtls didn't find/complete **`assertThat`** from AssertJ.

cause: `assertThat` is a **static** method, and jdtls only completes / auto-imports static members listed in `java.completion.favoriteStaticMembers`. that list defaults to **JUnit + Mockito** -- **not AssertJ** -- so assertj static methods were never suggested or imported.

fix: set `settings.java.completion.favoriteStaticMembers` to include **`org.assertj.core.api.Assertions.*`** (+ Assumptions / InstanceOfAssertFactories), keeping the junit/mockito defaults.

## file

- `jdtls.lua` (mac + linux)

## note

- assertj must still be a **testImplementation** dep and the file under **src/test/java** for it to be on the classpath. if `assertThat` is still red after this, run **SPC j d** to refresh, or check the dependency.

restart nvim after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)