### PR TITLE
fix(nvim): neogit commit editor in the same tab

### DIFF
--- a/linux/.config/nvim/lua/plugins/neogit.lua
+++ b/linux/.config/nvim/lua/plugins/neogit.lua
@@ -14,5 +14,10 @@ return {
     -- Open the status in the current window (same project tab) instead of a new
     -- tab. Neogit restores the previous buffer when the status is closed.
     kind = "replace",
+    -- The commit editor defaults to "tab"; open it as a split so it stays in the
+    -- same tab as the Neogit status instead of spawning a new tab.
+    commit_editor = {
+      kind = "split",
+    },
   },
 }

--- a/macbook/.config/nvim/lua/plugins/neogit.lua
+++ b/macbook/.config/nvim/lua/plugins/neogit.lua
@@ -14,5 +14,10 @@ return {
     -- Open the status in the current window (same project tab) instead of a new
     -- tab. Neogit restores the previous buffer when the status is closed.
     kind = "replace",
+    -- The commit editor defaults to "tab"; open it as a split so it stays in the
+    -- same tab as the Neogit status instead of spawning a new tab.
+    commit_editor = {
+      kind = "split",
+    },
   },
 }


### PR DESCRIPTION
## what

the neogit commit message screen opened in a **new tab**. its `commit_editor.kind` default is `tab`.

set **`commit_editor.kind = "split"`** so the commit editor opens as a split in the **same tab** as the neogit status.

## file

- `neogit.lua` (mac + linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)