### PR TITLE
feat(nvim): neo-tree shows hidden + gitignored files

### DIFF
--- a/linux/.config/nvim/lua/plugins/neo-tree.lua
+++ b/linux/.config/nvim/lua/plugins/neo-tree.lua
@@ -24,6 +24,12 @@ return {
       follow_current_file = { enabled = true }, -- track the active buffer
       use_libuv_file_watcher = true, -- live-refresh on external file changes
       hijack_netrw_behavior = "disabled", -- leave netrw/dirs to oil
+      -- Show everything: dotfiles and gitignored files included.
+      filtered_items = {
+        visible = true, -- show filtered items rather than hiding them
+        hide_dotfiles = false,
+        hide_gitignored = false,
+      },
     },
   },
 }

--- a/macbook/.config/nvim/lua/plugins/neo-tree.lua
+++ b/macbook/.config/nvim/lua/plugins/neo-tree.lua
@@ -24,6 +24,12 @@ return {
       follow_current_file = { enabled = true }, -- track the active buffer
       use_libuv_file_watcher = true, -- live-refresh on external file changes
       hijack_netrw_behavior = "disabled", -- leave netrw/dirs to oil
+      -- Show everything: dotfiles and gitignored files included.
+      filtered_items = {
+        visible = true, -- show filtered items rather than hiding them
+        hide_dotfiles = false,
+        hide_gitignored = false,
+      },
     },
   },
 }


### PR DESCRIPTION
## what

**SPC o p** (neo-tree) hid dotfiles and gitignored files. now it shows **everything**.

set `filesystem.filtered_items`:
- `visible = true`
- `hide_dotfiles = false`
- `hide_gitignored = false`

## file

- `neo-tree.lua` (mac + linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)