### PR TITLE
feat(nvim): find_files shows hidden + gitignored

### DIFF
--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -43,9 +43,10 @@ return {
       preview = { treesitter = false },
     },
     pickers = {
-      -- rg --files respects .gitignore; avoids `find` fallback that lists ignored files
+      -- rg --files listing everything: --hidden shows dotfiles, --no-ignore shows
+      -- gitignored files; exclude .git so the picker isn't flooded with git internals.
       find_files = {
-        find_command = { "rg", "--files", "--color", "never" },
+        find_command = { "rg", "--files", "--hidden", "--no-ignore", "--glob", "!.git", "--color", "never" },
       },
     },
   },

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -43,9 +43,10 @@ return {
       preview = { treesitter = false },
     },
     pickers = {
-      -- rg --files respects .gitignore; avoids `find` fallback that lists ignored files
+      -- rg --files listing everything: --hidden shows dotfiles, --no-ignore shows
+      -- gitignored files; exclude .git so the picker isn't flooded with git internals.
       find_files = {
-        find_command = { "rg", "--files", "--color", "never" },
+        find_command = { "rg", "--files", "--hidden", "--no-ignore", "--glob", "!.git", "--color", "never" },
       },
     },
   },


### PR DESCRIPTION
## what

**SPC SPC** (find_files) skipped hidden and gitignored files.

find_command now: `rg --files --hidden --no-ignore --glob !.git`
- **--hidden** -> dotfiles
- **--no-ignore** -> gitignored files
- **--glob !.git** -> keep git internals out of the picker

## file

- `telescope.lua` (mac + linux)

## note

only find_files (SPC SPC) changed. if you also want **live_grep** (SPC s p) to search hidden/ignored, that's a separate flag -- say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)