### PR TITLE
fix(nvim): multi-module gradle — test the right module + search all modules

### DIFF
--- a/linux/.config/nvim/lua/config/test.lua
+++ b/linux/.config/nvim/lua/config/test.lua
@@ -113,23 +113,31 @@ local function gradle_root()
   return vim.fs.root(0, { "gradlew", "settings.gradle", "settings.gradle.kts" })
 end
 
-local function run(root, target, label)
+-- Gradle project prefix for the current file's module, e.g. ":optimizer:". A
+-- multi-module build must qualify the task (":optimizer:test") -- an unqualified
+-- "test" runs every module, and modules without the --tests match fail with
+-- "No tests found for given includes". Empty for a single-module build (build
+-- file at the Gradle root), so tasks stay unqualified there.
+local function module_prefix(root)
+  local module_dir = vim.fs.root(0, { "build.gradle", "build.gradle.kts" })
+  if not module_dir or module_dir == root then
+    return ""
+  end
+  return ":" .. module_dir:sub(#root + 2):gsub("/", ":") .. ":"
+end
+
+local function run(root, tasks, target, label)
   if state.job then
     vim.notify("A test is already running", vim.log.levels.WARN)
     return
   end
+  -- tasks are module-qualified (":optimizer:cleanTest", ":optimizer:test");
   -- cleanTest forces re-run across Gradle versions; --tests filters to our fqn;
   -- --init-script turns on full failure logging. No --console: in the pty Gradle
   -- auto-detects a terminal and emits colour.
-  local cmd = {
-    root .. "/gradlew",
-    "cleanTest",
-    "test",
-    "--tests",
-    target,
-    "--init-script",
-    init_script(),
-  }
+  local cmd = { root .. "/gradlew" }
+  vim.list_extend(cmd, tasks)
+  vim.list_extend(cmd, { "--tests", target, "--init-script", init_script() })
 
   open_window() -- sized before the job so the pty gets the right width
   local old = out.buf
@@ -152,7 +160,7 @@ local function run(root, target, label)
   vim.keymap.set("n", "q", close_output, { buffer = out.buf, nowait = true, desc = "Close test output" })
   vim.keymap.set("n", "<Esc>", close_output, { buffer = out.buf, nowait = true, desc = "Close test output" })
 
-  state.last = { root = root, target = target, label = label }
+  state.last = { root = root, tasks = tasks, target = target, label = label }
 end
 
 function M.run_nearest()
@@ -166,7 +174,9 @@ function M.run_nearest()
     vim.notify("No test method/class at the cursor (open a .java test file)", vim.log.levels.WARN)
     return
   end
-  run(root, target, name or target)
+  local prefix = module_prefix(root)
+  local tasks = { prefix .. "cleanTest", prefix .. "test" }
+  run(root, tasks, target, name or target)
 end
 
 function M.run_last()
@@ -174,7 +184,7 @@ function M.run_last()
     vim.notify("No test has been run yet", vim.log.levels.INFO)
     return -- no-op
   end
-  run(state.last.root, state.last.target, state.last.label)
+  run(state.last.root, state.last.tasks, state.last.target, state.last.label)
 end
 
 return M

--- a/linux/.config/nvim/lua/plugins/project.lua
+++ b/linux/.config/nvim/lua/plugins/project.lua
@@ -16,14 +16,20 @@ return {
       -- keep auto-cd tab-local so each project tab holds its own cwd
       scope_chdir = "tab",
       detection_methods = { "pattern", "lsp" },
+      -- Root at the OUTERMOST project dir. A submodule's own build.gradle /
+      -- pom.xml is deliberately NOT a marker, else opening a multi-module file
+      -- (e.g. metadata-next/optimizer) would cd into the submodule and SPC SPC
+      -- would only search that module. settings.gradle(.kts) / gradlew / mvnw /
+      -- .git sit at the true root, so cwd covers every sibling module.
       patterns = {
         ".git",
+        "settings.gradle",
+        "settings.gradle.kts",
+        "gradlew",
+        "mvnw",
         "package.json",
         "Cargo.toml",
         "go.mod",
-        "pom.xml",
-        "build.gradle",
-        "settings.gradle",
         ".root",
       },
     })

--- a/linux/.config/nvim/lua/plugins/telescope.lua
+++ b/linux/.config/nvim/lua/plugins/telescope.lua
@@ -46,7 +46,24 @@ return {
       -- rg --files listing everything: --hidden shows dotfiles, --no-ignore shows
       -- gitignored files; exclude .git so the picker isn't flooded with git internals.
       find_files = {
-        find_command = { "rg", "--files", "--hidden", "--no-ignore", "--glob", "!.git", "--color", "never" },
+        -- --no-ignore surfaces gitignored files on purpose; still drop the noisy
+        -- build output (Gradle/Maven `build`/`target` dirs) and compiled .class.
+        find_command = {
+          "rg",
+          "--files",
+          "--hidden",
+          "--no-ignore",
+          "--glob",
+          "!.git",
+          "--glob",
+          "!**/build/**",
+          "--glob",
+          "!**/target/**",
+          "--glob",
+          "!*.class",
+          "--color",
+          "never",
+        },
       },
     },
   },

--- a/macbook/.config/nvim/lua/config/test.lua
+++ b/macbook/.config/nvim/lua/config/test.lua
@@ -113,23 +113,31 @@ local function gradle_root()
   return vim.fs.root(0, { "gradlew", "settings.gradle", "settings.gradle.kts" })
 end
 
-local function run(root, target, label)
+-- Gradle project prefix for the current file's module, e.g. ":optimizer:". A
+-- multi-module build must qualify the task (":optimizer:test") -- an unqualified
+-- "test" runs every module, and modules without the --tests match fail with
+-- "No tests found for given includes". Empty for a single-module build (build
+-- file at the Gradle root), so tasks stay unqualified there.
+local function module_prefix(root)
+  local module_dir = vim.fs.root(0, { "build.gradle", "build.gradle.kts" })
+  if not module_dir or module_dir == root then
+    return ""
+  end
+  return ":" .. module_dir:sub(#root + 2):gsub("/", ":") .. ":"
+end
+
+local function run(root, tasks, target, label)
   if state.job then
     vim.notify("A test is already running", vim.log.levels.WARN)
     return
   end
+  -- tasks are module-qualified (":optimizer:cleanTest", ":optimizer:test");
   -- cleanTest forces re-run across Gradle versions; --tests filters to our fqn;
   -- --init-script turns on full failure logging. No --console: in the pty Gradle
   -- auto-detects a terminal and emits colour.
-  local cmd = {
-    root .. "/gradlew",
-    "cleanTest",
-    "test",
-    "--tests",
-    target,
-    "--init-script",
-    init_script(),
-  }
+  local cmd = { root .. "/gradlew" }
+  vim.list_extend(cmd, tasks)
+  vim.list_extend(cmd, { "--tests", target, "--init-script", init_script() })
 
   open_window() -- sized before the job so the pty gets the right width
   local old = out.buf
@@ -152,7 +160,7 @@ local function run(root, target, label)
   vim.keymap.set("n", "q", close_output, { buffer = out.buf, nowait = true, desc = "Close test output" })
   vim.keymap.set("n", "<Esc>", close_output, { buffer = out.buf, nowait = true, desc = "Close test output" })
 
-  state.last = { root = root, target = target, label = label }
+  state.last = { root = root, tasks = tasks, target = target, label = label }
 end
 
 function M.run_nearest()
@@ -166,7 +174,9 @@ function M.run_nearest()
     vim.notify("No test method/class at the cursor (open a .java test file)", vim.log.levels.WARN)
     return
   end
-  run(root, target, name or target)
+  local prefix = module_prefix(root)
+  local tasks = { prefix .. "cleanTest", prefix .. "test" }
+  run(root, tasks, target, name or target)
 end
 
 function M.run_last()
@@ -174,7 +184,7 @@ function M.run_last()
     vim.notify("No test has been run yet", vim.log.levels.INFO)
     return -- no-op
   end
-  run(state.last.root, state.last.target, state.last.label)
+  run(state.last.root, state.last.tasks, state.last.target, state.last.label)
 end
 
 return M

--- a/macbook/.config/nvim/lua/plugins/project.lua
+++ b/macbook/.config/nvim/lua/plugins/project.lua
@@ -16,14 +16,20 @@ return {
       -- keep auto-cd tab-local so each project tab holds its own cwd
       scope_chdir = "tab",
       detection_methods = { "pattern", "lsp" },
+      -- Root at the OUTERMOST project dir. A submodule's own build.gradle /
+      -- pom.xml is deliberately NOT a marker, else opening a multi-module file
+      -- (e.g. metadata-next/optimizer) would cd into the submodule and SPC SPC
+      -- would only search that module. settings.gradle(.kts) / gradlew / mvnw /
+      -- .git sit at the true root, so cwd covers every sibling module.
       patterns = {
         ".git",
+        "settings.gradle",
+        "settings.gradle.kts",
+        "gradlew",
+        "mvnw",
         "package.json",
         "Cargo.toml",
         "go.mod",
-        "pom.xml",
-        "build.gradle",
-        "settings.gradle",
         ".root",
       },
     })

--- a/macbook/.config/nvim/lua/plugins/telescope.lua
+++ b/macbook/.config/nvim/lua/plugins/telescope.lua
@@ -46,7 +46,24 @@ return {
       -- rg --files listing everything: --hidden shows dotfiles, --no-ignore shows
       -- gitignored files; exclude .git so the picker isn't flooded with git internals.
       find_files = {
-        find_command = { "rg", "--files", "--hidden", "--no-ignore", "--glob", "!.git", "--color", "never" },
+        -- --no-ignore surfaces gitignored files on purpose; still drop the noisy
+        -- build output (Gradle/Maven `build`/`target` dirs) and compiled .class.
+        find_command = {
+          "rg",
+          "--files",
+          "--hidden",
+          "--no-ignore",
+          "--glob",
+          "!.git",
+          "--glob",
+          "!**/build/**",
+          "--glob",
+          "!**/target/**",
+          "--glob",
+          "!*.class",
+          "--color",
+          "never",
+        },
       },
     },
   },


### PR DESCRIPTION
## What

Two multi-module Gradle fixes (e.g. `metadata-next`: common/schema/api/elt/optimizer).

## 1. Run tests against the file's module (`SPC j t`)

`config/test.lua` ran an **unqualified** `cleanTest test --tests <fqn>` from the multi-module root, so Gradle ran `test` in *every* module; modules without the test (`:elt`, …) failed with `No tests found for given includes` → whole build failed.

Fix: qualify with the file's module → `:optimizer:cleanTest :optimizer:test`. Single-module builds stay unqualified. `--dry-run` confirmed it targets only `:optimizer`.

## 2. Search all modules with `SPC SPC`

project.nvim auto-cd'd into the **submodule** (its own `build.gradle` was a root marker), so `rg --files` only saw that module. Dropped submodule build files (`build.gradle`, `pom.xml`) from the patterns; root now on `settings.gradle(.kts)` / `gradlew` / `mvnw` / `.git` — the true root.

Verified: opening `metadata-next/optimizer/...` roots at `metadata-next`, and `rg --files` returns files from all five modules.

macbook + linux both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)