### PR TITLE
fix(nvim): oil enter on ../ go up not back down

### DIFF
--- a/linux/.config/nvim/lua/plugins/oil.lua
+++ b/linux/.config/nvim/lua/plugins/oil.lua
@@ -31,7 +31,9 @@ local function open_entry()
   local oil = require("oil")
   local entry = oil.get_cursor_entry()
   local dir = oil.get_current_dir()
-  if entry and dir and entry.type == "directory" then
+  -- Let the parent entry (`../`) fall through to oil's default select, so CR on
+  -- it goes up one level instead of descending back into the current dir.
+  if entry and dir and entry.type == "directory" and entry.name ~= ".." then
     oil.open(first_nonempty(dir .. entry.name))
   else
     oil.select()

--- a/macbook/.config/nvim/lua/plugins/oil.lua
+++ b/macbook/.config/nvim/lua/plugins/oil.lua
@@ -31,7 +31,9 @@ local function open_entry()
   local oil = require("oil")
   local entry = oil.get_cursor_entry()
   local dir = oil.get_current_dir()
-  if entry and dir and entry.type == "directory" then
+  -- Let the parent entry (`../`) fall through to oil's default select, so CR on
+  -- it goes up one level instead of descending back into the current dir.
+  if entry and dir and entry.type == "directory" and entry.name ~= ".." then
     oil.open(first_nonempty(dir .. entry.name))
   else
     oil.select()


### PR DESCRIPTION
oil skip-empty-packages made enter on parent (../) run descend logic. it bounced back into same dir. now parent entry fall through to oil default select. go up work again.