### PR TITLE
feat(nvim): SPC c x list LSP problems in bottom window

### DIFF
--- a/linux/.config/nvim/lua/config/diagnostics.lua
+++ b/linux/.config/nvim/lua/config/diagnostics.lua
@@ -1,0 +1,58 @@
+-- Diagnostics (LSP problems) list. Bound in config/keymaps.lua under SPC c x.
+-- Collects every diagnostic across loaded buffers into the quickfix list and
+-- opens it in a window at the bottom. Ordering: errors first (by severity), and
+-- within each severity the CURRENT file's problems come first. In the list:
+--   <CR>  jump to the problem's file/line
+--   j / k move between problems (or n / N)
+--   Q     close the list
+local M = {}
+
+-- quickfix `type` letter per diagnostic severity.
+local function type_char(severity)
+  local s = vim.diagnostic.severity
+  return ({ [s.ERROR] = "E", [s.WARN] = "W", [s.INFO] = "I", [s.HINT] = "N" })[severity] or "E"
+end
+
+function M.show()
+  local cur = vim.api.nvim_get_current_buf()
+  local diags = vim.diagnostic.get(nil) -- all loaded buffers
+  if vim.tbl_isempty(diags) then
+    vim.notify("No diagnostics", vim.log.levels.INFO)
+    return
+  end
+
+  -- Sort: severity first (ERROR=1 < WARN=2 < INFO=3 < HINT=4), then the current
+  -- buffer ahead of others, then group by buffer and line.
+  table.sort(diags, function(a, b)
+    if a.severity ~= b.severity then
+      return a.severity < b.severity
+    end
+    local a_cur, b_cur = a.bufnr == cur, b.bufnr == cur
+    if a_cur ~= b_cur then
+      return a_cur
+    end
+    if a.bufnr ~= b.bufnr then
+      return a.bufnr < b.bufnr
+    end
+    return a.lnum < b.lnum
+  end)
+
+  local items = {}
+  for _, d in ipairs(diags) do
+    items[#items + 1] = {
+      bufnr = d.bufnr,
+      lnum = d.lnum + 1, -- diagnostics are 0-based; quickfix is 1-based
+      col = d.col + 1,
+      text = d.message,
+      type = type_char(d.severity),
+    }
+  end
+
+  vim.fn.setqflist({}, " ", { title = "Diagnostics", items = items })
+  vim.cmd("botright copen") -- window at the bottom, spanning the full width
+  local buf = vim.api.nvim_get_current_buf()
+  -- Q closes the list (quickfix already jumps on <CR> and moves with j/k).
+  vim.keymap.set("n", "Q", "<cmd>cclose<CR>", { buffer = buf, nowait = true, desc = "Close diagnostics" })
+end
+
+return M

--- a/linux/.config/nvim/lua/config/keymaps.lua
+++ b/linux/.config/nvim/lua/config/keymaps.lua
@@ -53,6 +53,11 @@ map("n", "<leader>bc", function()
   require("config.git").create_branch()
 end, { desc = "Create git branch" })
 
+-- SPC c — code (group also populated in plugins/lsp.lua via on_attach)
+map("n", "<leader>cx", function()
+  require("config.diagnostics").show()
+end, { desc = "List diagnostics (problems)" })
+
 -- SPC f — file
 map("n", "<leader>fs", "<cmd>w<CR>", { desc = "Save file" })
 map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })

--- a/macbook/.config/nvim/lua/config/diagnostics.lua
+++ b/macbook/.config/nvim/lua/config/diagnostics.lua
@@ -1,0 +1,58 @@
+-- Diagnostics (LSP problems) list. Bound in config/keymaps.lua under SPC c x.
+-- Collects every diagnostic across loaded buffers into the quickfix list and
+-- opens it in a window at the bottom. Ordering: errors first (by severity), and
+-- within each severity the CURRENT file's problems come first. In the list:
+--   <CR>  jump to the problem's file/line
+--   j / k move between problems (or n / N)
+--   Q     close the list
+local M = {}
+
+-- quickfix `type` letter per diagnostic severity.
+local function type_char(severity)
+  local s = vim.diagnostic.severity
+  return ({ [s.ERROR] = "E", [s.WARN] = "W", [s.INFO] = "I", [s.HINT] = "N" })[severity] or "E"
+end
+
+function M.show()
+  local cur = vim.api.nvim_get_current_buf()
+  local diags = vim.diagnostic.get(nil) -- all loaded buffers
+  if vim.tbl_isempty(diags) then
+    vim.notify("No diagnostics", vim.log.levels.INFO)
+    return
+  end
+
+  -- Sort: severity first (ERROR=1 < WARN=2 < INFO=3 < HINT=4), then the current
+  -- buffer ahead of others, then group by buffer and line.
+  table.sort(diags, function(a, b)
+    if a.severity ~= b.severity then
+      return a.severity < b.severity
+    end
+    local a_cur, b_cur = a.bufnr == cur, b.bufnr == cur
+    if a_cur ~= b_cur then
+      return a_cur
+    end
+    if a.bufnr ~= b.bufnr then
+      return a.bufnr < b.bufnr
+    end
+    return a.lnum < b.lnum
+  end)
+
+  local items = {}
+  for _, d in ipairs(diags) do
+    items[#items + 1] = {
+      bufnr = d.bufnr,
+      lnum = d.lnum + 1, -- diagnostics are 0-based; quickfix is 1-based
+      col = d.col + 1,
+      text = d.message,
+      type = type_char(d.severity),
+    }
+  end
+
+  vim.fn.setqflist({}, " ", { title = "Diagnostics", items = items })
+  vim.cmd("botright copen") -- window at the bottom, spanning the full width
+  local buf = vim.api.nvim_get_current_buf()
+  -- Q closes the list (quickfix already jumps on <CR> and moves with j/k).
+  vim.keymap.set("n", "Q", "<cmd>cclose<CR>", { buffer = buf, nowait = true, desc = "Close diagnostics" })
+end
+
+return M

--- a/macbook/.config/nvim/lua/config/keymaps.lua
+++ b/macbook/.config/nvim/lua/config/keymaps.lua
@@ -53,6 +53,11 @@ map("n", "<leader>bc", function()
   require("config.git").create_branch()
 end, { desc = "Create git branch" })
 
+-- SPC c — code (group also populated in plugins/lsp.lua via on_attach)
+map("n", "<leader>cx", function()
+  require("config.diagnostics").show()
+end, { desc = "List diagnostics (problems)" })
+
 -- SPC f — file
 map("n", "<leader>fs", "<cmd>w<CR>", { desc = "Save file" })
 map("n", "<leader>fS", "<cmd>wa<CR>", { desc = "Save all files" })


### PR DESCRIPTION
new command SPC c x show all lsp problems.

- open list window at bottom
- errors first (by severity), warning after
- problems of the file you have open come first of all
- press CR on a problem: jump to its file/line
- j/k move between problems
- Q close the window