### PR TITLE
feat(nvim): kotlin treesitter syntax highlighting

### DIFF
--- a/linux/.config/nvim/lua/plugins/treesitter.lua
+++ b/linux/.config/nvim/lua/plugins/treesitter.lua
@@ -4,6 +4,7 @@
 -- FileType. Indentation uses the plugin's indentexpr.
 local ensure = {
   "java",
+  "kotlin", -- .kt / .kts (also build.gradle.kts)
   "lua",
   "markdown",
   "markdown_inline",

--- a/macbook/.config/nvim/lua/plugins/treesitter.lua
+++ b/macbook/.config/nvim/lua/plugins/treesitter.lua
@@ -4,6 +4,7 @@
 -- FileType. Indentation uses the plugin's indentexpr.
 local ensure = {
   "java",
+  "kotlin", -- .kt / .kts (also build.gradle.kts)
   "lua",
   "markdown",
   "markdown_inline",


### PR DESCRIPTION
add kotlin parser to treesitter ensure list. cover .kt / .kts (also build.gradle.kts).

FileType autocmd already turn on highlight + indent when parser present, so no other change need.

note: kotlin parser build from source, need tree-sitter CLI (already in setup).