### PR TITLE
feat(nvim): format kotlin with ktlint on SPC c f

### DIFF
--- a/linux/.config/nvim/lua/plugins/conform.lua
+++ b/linux/.config/nvim/lua/plugins/conform.lua
@@ -77,6 +77,11 @@ return {
       formatters_by_ft = {
         java = { "spotless" },
         groovy = { "spotless" }, -- build.gradle, when the project's Spotless targets it
+        -- Kotlin (.kt + build.gradle.kts): ktlint. The JetBrains kotlin-lsp's LSP
+        -- formatting is unreliable on build scripts, so use a dedicated formatter.
+        -- Install once per machine: :MasonInstall ktlint (mason's bin is on
+        -- conform's PATH, so no extra config needed).
+        kotlin = { "ktlint" },
       },
     }
   end,

--- a/macbook/.config/nvim/lua/plugins/conform.lua
+++ b/macbook/.config/nvim/lua/plugins/conform.lua
@@ -77,6 +77,11 @@ return {
       formatters_by_ft = {
         java = { "spotless" },
         groovy = { "spotless" }, -- build.gradle, when the project's Spotless targets it
+        -- Kotlin (.kt + build.gradle.kts): ktlint. The JetBrains kotlin-lsp's LSP
+        -- formatting is unreliable on build scripts, so use a dedicated formatter.
+        -- Install once per machine: :MasonInstall ktlint (mason's bin is on
+        -- conform's PATH, so no extra config needed).
+        kotlin = { "ktlint" },
       },
     }
   end,


### PR DESCRIPTION
kotlin file had no conform formatter, so SPC c f did nothing (kotlin-lsp LSP format is unreliable, specially on .gradle.kts).

- map kotlin -> ktlint in conform (cover .kt and build.gradle.kts)
- mason bin already on conform PATH, so no extra wiring

after merge: git pull, restart nvim, run :MasonInstall ktlint once per machine, then SPC c f on a kotlin file.